### PR TITLE
Add unit test for the grep helper function

### DIFF
--- a/test/toolshed/unix_test.exs
+++ b/test/toolshed/unix_test.exs
@@ -20,4 +20,12 @@ defmodule Toolshed.UnixTest do
   test "tree/1 prints directories and files in tree form" do
     assert capture_io(fn -> Unix.tree("test/support") end) == "test/support\n└── test_file.doc\n"
   end
+
+  test "grep/2 returns lines of file with given pattern" do
+    assert capture_io(fn -> Unix.grep(~r/Content/, "test/support/test_file.doc") end) ==
+             "Content of this will be read for test purposes"
+
+    assert capture_io(fn -> Unix.grep(~r/not available/, "test/support/test_file.doc") end) ==
+             ""
+  end
 end


### PR DESCRIPTION
This is add unit test for the grep/2 function used to search for
a given pattern in a specified file(s)