### PR TITLE
Add unit test for uptime helper function

### DIFF
--- a/test/toolshed/unix_test.exs
+++ b/test/toolshed/unix_test.exs
@@ -28,4 +28,10 @@ defmodule Toolshed.UnixTest do
     assert capture_io(fn -> Unix.grep(~r/not available/, "test/support/test_file.doc") end) ==
              ""
   end
+
+  test "uptime/0 return current uptime" do
+    output = capture_io(&Unix.uptime/0)
+    assert String.length(output) > 0
+    assert String.ends_with?(output, "\n")
+  end
 end


### PR DESCRIPTION
This adds unit test for already existing Toolshed.Unix.uptime/0 which
returns the current uptime