### PR TITLE
Update cmd/1 to use `binstream` instead of `stream`

### DIFF
--- a/lib/toolshed.ex
+++ b/lib/toolshed.ex
@@ -93,7 +93,7 @@ defmodule Toolshed do
   @spec cmd(String.t() | charlist()) :: integer()
   def cmd(str) when is_binary(str) do
     {_collectable, exit_code} =
-      System.cmd("sh", ["-c", str], stderr_to_stdout: true, into: IO.stream(:stdio, :line))
+      System.cmd("sh", ["-c", str], stderr_to_stdout: true, into: IO.binstream(:stdio, :line))
 
     exit_code
   end

--- a/test/toolshed_test.exs
+++ b/test/toolshed_test.exs
@@ -1,3 +1,16 @@
 defmodule ToolshedTest do
   use ExUnit.Case
+  import ExUnit.CaptureIO
+
+  test "cmd/1 normal printable chars" do
+    assert capture_io(fn ->
+             Toolshed.cmd("echo \"hello, world\"")
+           end) == "hello, world\n"
+  end
+
+  test "cmd/1 non printable chars" do
+    assert capture_io(fn ->
+             Toolshed.cmd("echo -e -n '\\x0'")
+           end) == <<0>>
+  end
 end


### PR DESCRIPTION
This is needed to prevent crashing when a command writes non-unicode values to stdout.