### PR TITLE
log attach

### DIFF
--- a/lib/toolshed.ex
+++ b/lib/toolshed.ex
@@ -22,6 +22,8 @@ defmodule Toolshed do
     * `hostname/0`     - print our hostname
     * `ifconfig/0`     - print info on network interfaces
     * `load_term!/2`   - load a term that was saved by `save_term/2`
+    * `log_attach/1`   - send log messages to the current group leader
+    * `log_detach/0`   - stop sending log messages to the current group leader
     * `lsof/0`         - print out open file handles by OS process
     * `lsmod/0`        - print out what kernel modules have been loaded (Nerves-only)
     * `lsusb/0`        - print info on USB devices
@@ -65,6 +67,8 @@ defmodule Toolshed do
       import Toolshed.HTTP
       import Toolshed.Multicast
       import Toolshed.Date, only: [date: 0]
+      import Toolshed.Log, only: [log_attach: 0, log_attach: 1, log_detach: 0]
+
       # If module docs have been stripped, then don't tell the user that they can
       # see them.
       help_text =

--- a/lib/toolshed/log.ex
+++ b/lib/toolshed/log.ex
@@ -1,0 +1,78 @@
+defmodule Toolshed.Log do
+  @moduledoc """
+  Utilities for attaching and detaching to the log
+
+  These utilities configure Elixir's console backend to attach
+  to the current group leader. This makes it work over `ssh` sessions
+  and play well with the IEx prompt.
+  """
+
+  @doc """
+  Attach the current session to the Elixir logger
+
+  This forwards incoming log messages to the terminal. Call `detach/0` to stop
+  the messages.
+
+  Behind the scenes, this uses Elixir's built-in console logger and can be
+  configured similarly. See the [Logger console backend
+  documentation](https://hexdocs.pm/logger/Logger.html#module-console-backend)
+  for details. The following are useful options:
+
+  * `:level` - the minimum log level to report. E.g., specify `level: :warning`
+    to only see warnings and errors.
+  * `:metadata` - a list of metadata keys to show or `:all`
+
+  Unspecified options use either the console backend's default or those found
+  in the application environment for the `:console` Logger backend.
+  """
+  @spec log_attach(keyword()) :: {:error, any} | {:ok, :undefined | pid}
+  def log_attach(options \\ []) do
+    case Process.get(__MODULE__) do
+      nil ->
+        all_options = Keyword.put(options, :device, Process.group_leader())
+        backend = {Logger.Backends.Console, all_options}
+
+        {:ok, pid} = GenServer.start(Toolshed.Log.Watcher, {Process.group_leader(), backend})
+
+        Process.put(__MODULE__, {pid, backend})
+
+        Logger.add_backend({Logger.Backends.Console, all_options})
+
+      _other ->
+        {:error, :detach_first}
+    end
+  end
+
+  @doc """
+  Detach the current session from the Elixir logger
+  """
+  @spec log_detach :: :ok | {:error, :not_attached | :not_found}
+  def log_detach() do
+    case Process.get(__MODULE__) do
+      nil ->
+        {:error, :not_attached}
+
+      {pid, backend} ->
+        Process.delete(__MODULE__)
+        GenServer.stop(pid)
+        Logger.remove_backend(backend)
+    end
+  end
+
+  defmodule Watcher do
+    @moduledoc false
+    use GenServer
+
+    @impl GenServer
+    def init({watch_pid, backend}) do
+      Process.monitor(watch_pid)
+      {:ok, backend}
+    end
+
+    @impl GenServer
+    def handle_info({:DOWN, _ref, :process, _pid, _reason}, backend) do
+      _ = Logger.remove_backend(backend)
+      {:stop, :normal, backend}
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,7 @@ defmodule Toolshed.MixProject do
   end
 
   def application do
-    [extra_applications: [:iex]]
+    [extra_applications: [:iex, :logger]]
   end
 
   defp deps do

--- a/test/toolshed/log_test.exs
+++ b/test/toolshed/log_test.exs
@@ -1,0 +1,75 @@
+defmodule Toolshed.LogTest do
+  use ExUnit.Case
+
+  import ExUnit.CaptureIO
+  import ExUnit.CaptureLog
+  require Logger
+
+  alias Toolshed.Log
+
+  @default_options [format: "unittest[$level] $message\n", colors: [enabled: false]]
+
+  defp capture_io_and_not_log(function) do
+    capture_io(fn -> capture_log(function) end)
+  end
+
+  test "logging events while attached and detached" do
+    output =
+      capture_io_and_not_log(fn ->
+        Log.log_attach(@default_options)
+        Logger.info("hello1")
+        Log.log_detach()
+        Logger.error("shouldn't log")
+      end)
+
+    assert output == "unittest[info] hello1\n"
+  end
+
+  test "detaching returns an error when not attached" do
+    assert {:error, :not_attached} = Log.log_detach()
+  end
+
+  test "attaching twice returns an error" do
+    assert {:ok, _pid} = Log.log_attach()
+    assert {:error, :detach_first} == Log.log_attach()
+    assert :ok == Log.log_detach()
+  end
+
+  test "filtering by log level" do
+    output =
+      capture_io_and_not_log(fn ->
+        {:ok, _pid} = Log.log_attach(@default_options ++ [level: :error])
+        Logger.error("hello1")
+        Logger.info("shouldn't log")
+      end)
+
+    assert output == "unittest[error] hello1\n"
+  end
+
+  defp backend_count() do
+    Logger.BackendSupervisor
+    |> Supervisor.count_children()
+    |> Map.get(:workers, 0)
+  end
+
+  test "detaches when group leader dies" do
+    old_gl = Process.group_leader()
+    {:ok, new_gl} = StringIO.open("")
+
+    Process.group_leader(self(), new_gl)
+
+    original_count = backend_count()
+
+    # Attach -> this should cause there to be a new backend
+    {:ok, _pid} = Log.log_attach(@default_options)
+    assert backend_count() == original_count + 1
+
+    # Set the group leader back and exit the new one we made
+    Process.group_leader(self(), old_gl)
+    StringIO.close(new_gl)
+
+    # Should be back to the original backend count
+    Process.sleep(10)
+    assert backend_count() == original_count
+  end
+end


### PR DESCRIPTION
- Replace echo with printf for portability
- Fix date test race condition
- v0.2.19 release
- Bump ex_doc from 0.24.1 to 0.24.2
- Upgrade to GitHub-native Dependabot
- Move date function to its own module
- Bump nerves_runtime from 0.11.3 to 0.11.4
- Add log_attach and log_detach
