### PR TITLE
Add ability to ping IPv6 addresses

### DIFF
--- a/lib/toolshed/net.ex
+++ b/lib/toolshed/net.ex
@@ -168,12 +168,20 @@ defmodule Toolshed.Net do
   end
 
   defp resolve_addr(address) do
-    with {:ok, hostent} <- :inet.gethostbyname(to_charlist(address)),
-         hostent(h_addr_list: ip_list) = hostent,
-         first_ip = hd(ip_list) do
-      {:ok, first_ip}
-    else
-      _ -> {:error, "Error resolving #{address}"}
+    case gethostbyname(address, :inet) || gethostbyname(address, :inet6) do
+      nil -> {:error, "Error resolving #{address}"}
+      ip -> {:ok, ip}
+    end
+  end
+
+  defp gethostbyname(address, family) do
+    case :inet.gethostbyname(to_charlist(address), family) do
+      {:ok, hostent} ->
+        hostent(h_addr_list: ip_list) = hostent
+        hd(ip_list)
+
+      _ ->
+        nil
     end
   end
 

--- a/test/toolshed/net_test.exs
+++ b/test/toolshed/net_test.exs
@@ -1,0 +1,35 @@
+defmodule Toolshed.NetTest do
+  use ExUnit.Case
+  import ExUnit.CaptureIO
+  alias Toolshed.Net
+
+  describe "tping" do
+    test "can ping an IPv4 address" do
+      assert capture_io(fn ->
+               Net.tping("127.0.0.1")
+             end) =~ "Response from 127.0.0.1 (127.0.0.1): time="
+    end
+
+    # This guards against an issue with IPv6 being unavailable in CI,
+    # but also means CI won't run this test.
+    unless System.get_env("CI") == "true" do
+      test "can ping an IPv6 address" do
+        assert capture_io(fn ->
+                 Net.tping("::1")
+               end) =~ "Response from ::1 (::1): time="
+      end
+    end
+
+    test "can ping by hostname" do
+      assert capture_io(fn ->
+               Net.tping("localhost")
+             end) =~ "Response from localhost (127.0.0.1): time="
+    end
+
+    test "prints an error if host can't be resolved" do
+      assert capture_io(fn ->
+               Net.tping("this.host.does.not.exist")
+             end) =~ "Error resolving this.host.does.not.exist"
+    end
+  end
+end


### PR DESCRIPTION
We recently needed the ability to ping IPv6 addresses due to using a type of network that doesn't support IPv4, so it seemed like a good opportunity to add this to Toolshed. This PR makes a small change to host resolution so that it attempts to resolve addresses for both `:inet` (IPv4) and `:inet6` (IPv6) before giving up. If both address families are available the IPv4 address is used, which should maintain backwards compatibility when pinging services on the Internet.