### PR TITLE
Pass rows/cols to top; reduce IO

### DIFF
--- a/lib/toolshed/top.ex
+++ b/lib/toolshed/top.ex
@@ -3,7 +3,10 @@ defmodule Toolshed.Top do
   Find the top processes
   """
 
-  @default_n 10
+  @default_rows 23
+  @default_columns 80
+
+  alias Toolshed.Top.Server
 
   @doc """
   Interactively show the top Elixir processes
@@ -16,24 +19,33 @@ defmodule Toolshed.Top do
   * `:order` - the sort order for the results (`:reductions`, `:delta_reductions`,
     `:mailbox`, `:delta_mailbox`, `:total_heap_size`, `:delta_total_heap_size`, `:heap_size`,
     `:delta_heap_size`, `:stack_size`, `:delta_stack_size`)
-  * `:n`     - the max number of processes to list
   """
   @spec top(keyword()) :: :ok
   def top(opts \\ []) do
-    options = process_options(opts)
+    options = %{
+      order: Keyword.get(opts, :order, :delta_reductions),
+      rows: rows(),
+      columns: columns()
+    }
 
     IO.puts("Press enter to stop\n")
 
-    {:ok, pid} = Toolshed.Top.Server.start_link(options)
+    {:ok, pid} = Server.start_link(options)
     _ = IO.gets("")
-    Toolshed.Top.Server.stop(pid)
+    Server.stop(pid)
   end
 
-  # TODO - validate options
-  defp process_options(opts) do
-    order = Keyword.get(opts, :order, :delta_reductions)
-    n = Keyword.get(opts, :n, @default_n)
+  defp rows() do
+    case :io.rows() do
+      {:ok, rows} -> rows
+      _ -> @default_rows
+    end
+  end
 
-    %{order: order, n: n}
+  defp columns() do
+    case :io.columns() do
+      {:ok, columns} -> columns
+      _ -> @default_columns
+    end
   end
 end

--- a/lib/toolshed/top/server.ex
+++ b/lib/toolshed/top/server.ex
@@ -29,12 +29,14 @@ defmodule Toolshed.Top.Server do
 
   @impl GenServer
   def handle_info(:refresh_top, state) do
-    Report.erase_report(state.options)
-    |> IO.write()
+    report =
+      Processes.info(state.processes)
+      |> Report.generate(state.options)
 
-    Processes.info(state.processes)
-    |> Report.generate(state.options)
-    |> IO.write()
+    IO.write([
+      Report.back_to_the_top(state.options),
+      report
+    ])
 
     {:noreply, state}
   end


### PR DESCRIPTION
This changes top so that it uses the current terminal's size (unless overridden) to 
determine how many rows to show.

A change made at the same time is to condense the I/O to one call to
IO.write. This should hopefully minimize flickering.

Fixes #90 