### PR TITLE
Use ICMP for ping command

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+elixir 1.12.2-otp-24
+erlang 24.0.4

--- a/test/toolshed/net_test.exs
+++ b/test/toolshed/net_test.exs
@@ -3,33 +3,50 @@ defmodule Toolshed.NetTest do
   import ExUnit.CaptureIO
   alias Toolshed.Net
 
-  describe "tping" do
-    test "can ping an IPv4 address" do
-      assert capture_io(fn ->
-               Net.tping("127.0.0.1")
-             end) =~ "Response from 127.0.0.1 (127.0.0.1): time="
-    end
+  # CI can't send ICMP packets.
+  unless System.get_env("CI") == "true" do
+    describe "tping" do
+      test "can ping an IPv4 address" do
+        assert capture_io(fn ->
+                 Net.tping("127.0.0.1")
+               end) =~ "Response from 127.0.0.1 (127.0.0.1): time="
+      end
 
-    # This guards against an issue with IPv6 being unavailable in CI,
-    # but also means CI won't run this test.
-    unless System.get_env("CI") == "true" do
       test "can ping an IPv6 address" do
         assert capture_io(fn ->
                  Net.tping("::1")
                end) =~ "Response from ::1 (::1): time="
       end
-    end
 
-    test "can ping by hostname" do
-      assert capture_io(fn ->
-               Net.tping("localhost")
-             end) =~ "Response from localhost (127.0.0.1): time="
-    end
+      test "can ping by hostname" do
+        assert capture_io(fn ->
+                 Net.tping("localhost")
+               end) =~ "Response from localhost (127.0.0.1): time="
+      end
 
-    test "prints an error if host can't be resolved" do
-      assert capture_io(fn ->
-               Net.tping("this.host.does.not.exist")
-             end) =~ "Error resolving this.host.does.not.exist"
+      test "times out if host doesn't exist" do
+        assert capture_io(fn ->
+                 Net.tping("0.0.0.1", timeout: 1)
+               end) =~ "0.0.0.1 (0.0.0.1): :timeout"
+      end
+
+      test "prints an error if host can't be resolved" do
+        assert capture_io(fn ->
+                 Net.tping("this.host.does.not.exist")
+               end) =~ "Error resolving this.host.does.not.exist"
+      end
+
+      test "can ping via a specific interface" do
+        assert capture_io(fn ->
+                 Net.tping("127.0.0.1", ifname: "lo")
+               end) =~ "Response from 127.0.0.1 (127.0.0.1): time="
+      end
+
+      test "prints an error if an interface is specified but not present" do
+        assert capture_io(fn ->
+                 Net.tping("127.0.0.1", ifname: "not-present")
+               end) =~ "127.0.0.1 (127.0.0.1): :eaddrnotavail"
+      end
     end
   end
 end


### PR DESCRIPTION
Resolves #81

This PR replaces the ping code that used TCP with an ICMP implementation. The interface maintains backwards compatibility with the former implementation.