### PR TITLE
Add a history command

### DIFF
--- a/lib/toolshed.ex
+++ b/lib/toolshed.ex
@@ -18,6 +18,7 @@ defmodule Toolshed do
     * `fw_validate/0`  - marks the current image as valid (check Nerves system if supported)
     * `grep/2`         - print out lines that match a regular expression
     * `hex/1`          - print a number as hex
+    * `history/0`      - print out the IEx shell history
     * `httpget/2`      - print or download the results of a HTTP GET request
     * `hostname/0`     - print our hostname
     * `ifconfig/0`     - print info on network interfaces
@@ -67,6 +68,7 @@ defmodule Toolshed do
       import Toolshed.HTTP
       import Toolshed.Multicast
       import Toolshed.Date, only: [date: 0]
+      import Toolshed.History, only: [history: 0, history: 1]
       import Toolshed.Log, only: [log_attach: 0, log_attach: 1, log_detach: 0]
 
       # If module docs have been stripped, then don't tell the user that they can

--- a/lib/toolshed/history.ex
+++ b/lib/toolshed/history.ex
@@ -1,0 +1,34 @@
+defmodule Toolshed.History do
+  @moduledoc false
+
+  @doc """
+  Print out the IEx shell history
+
+  The default is to print the history from the current group leader, but
+  any group leader can be passed in if desired.
+  """
+  @spec history(pid()) :: :"do not show this result in output"
+  def history(gl \\ Process.group_leader()) do
+    commands = last_commands(gl)
+    format = format_spec(length(commands))
+
+    commands
+    |> Enum.with_index(1)
+    |> Enum.map(fn {line, index} -> :io_lib.format(format, [index, line]) end)
+    |> IO.puts()
+
+    :"do not show this result in output"
+  end
+
+  defp last_commands(gl) do
+    case get_in(Process.info(gl), [:dictionary, :line_buffer]) do
+      nil -> []
+      list -> Enum.reverse(list)
+    end
+  end
+
+  defp format_spec(highest_number) do
+    number_size = :math.log10(highest_number + 1) |> ceil()
+    '~#{number_size}B  ~ts'
+  end
+end

--- a/test/toolshed/history_test.exs
+++ b/test/toolshed/history_test.exs
@@ -1,0 +1,25 @@
+defmodule Toolshed.HistoryTest do
+  use ExUnit.Case
+  import ExUnit.CaptureIO
+  alias Toolshed.History
+
+  test "history can print out commandline history" do
+    # Use this process as a fake group leader
+    Process.put(
+      :line_buffer,
+      ['Fourth command\n', 'Third command\n', 'Second command\n', 'First command\n']
+    )
+
+    fake_gl = self()
+
+    output = capture_io(fn -> History.history(fake_gl) end)
+
+    assert output == """
+           1  First command
+           2  Second command
+           3  Third command
+           4  Fourth command
+
+           """
+  end
+end


### PR DESCRIPTION
The purpose of the history command is to list out all of the previous
commands typed at the IEx prompt. This is nice when you want to see what
you did and refer to old commands. This information is in the group
leader, but inconvenient. This command fixes that.
