### PR TITLE
fw_validate: use Nerves.Runtime.validate_firmware

### DIFF
--- a/lib/toolshed/nerves.ex
+++ b/lib/toolshed/nerves.ex
@@ -47,16 +47,14 @@ if Code.ensure_loaded?(Nerves.Runtime) do
     """
     @spec fw_validate() :: :ok | {:error, String.t()}
     def fw_validate() do
-      try do
-        Nerves.Runtime.KV.put("nerves_fw_validated", "1")
-      catch
-        :error, :undef ->
-          # Fall back to the old Nerves way
-          case System.cmd("fw_setenv", ["nerves_fw_validated", "1"]) do
-            {_, 0} -> :ok
-            {output, _} -> {:error, output}
-          end
-      end
+      Nerves.Runtime.validate_firmware()
+    catch
+      :error, :undef ->
+        # Fall back to the old Nerves way
+        case System.cmd("fw_setenv", ["nerves_fw_validated", "1"]) do
+          {_, 0} -> :ok
+          {output, _} -> {:error, output}
+        end
     end
 
     @doc """


### PR DESCRIPTION
Nerves Runtime has had a method for validating firmware since v0.11.2
since May 2020. Use it since the firmware validation mechanism can be
platform specific. The old Nerves way will work find for anyone using a
really old version of Nerves, but a new version of Toolshed.
