### PR TITLE
Remove path completion on Elixir 1.13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,9 +19,20 @@ install_system_deps: &install_system_deps
         apk add build-base libmnl-dev
 
 jobs:
+  build_elixir_1_13_otp_24:
+    docker:
+      - image: hexpm/elixir:1.13.0-rc.1-erlang-24.1.5-alpine-3.14.2
+    <<: *defaults
+    steps:
+      - checkout
+      - <<: *install_hex_rebar
+      - <<: *install_system_deps
+      - run: mix deps.get
+      - run: mix test --exclude has_ipv6
+
   build_elixir_1_12_otp_24:
     docker:
-      - image: hexpm/elixir:1.12.0-erlang-24.0-alpine-3.13.3
+      - image: hexpm/elixir:1.12.3-erlang-24.1.5-alpine-3.14.2
     <<: *defaults
     steps:
       - checkout
@@ -96,6 +107,7 @@ workflows:
   version: 2
   build_test:
     jobs:
+      - build_elixir_1_13_otp_24
       - build_elixir_1_12_otp_24
       - build_elixir_1_11_otp_23
       - build_elixir_1_10_otp_23

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 [![Hex version](https://img.shields.io/hexpm/v/toolshed.svg "Hex version")](https://hex.pm/packages/toolshed)
 
 Toolshed aims to improve the Elixir shell experience by adding a number of
-helpers and path autocompletion. This is really helpful when a normal Unix shell
-prompt is unavailable or inconvenient. Toolshed was originally written for
+helpers. This is really helpful when a normal Unix shell prompt is unavailable
+or inconvenient. Toolshed was originally written for
 [Nerves](https://nerves-project.org), but doesn't require it and the
 Nerves-specific helpers are compiled out for normal Elixir projects.
 

--- a/lib/toolshed/autocomplete.ex
+++ b/lib/toolshed/autocomplete.ex
@@ -1,196 +1,210 @@
-defmodule Toolshed.Autocomplete do
-  @moduledoc """
-  Add path completion to the default IEx autocompletion
+# This code was improved and merged into Elixir 1.13.0, so it's no
+# longer needed.
+if Version.match?(System.version(), "< 1.13.0-rc.0") do
+  defmodule Toolshed.Autocomplete do
+    @moduledoc """
+    Add path completion to the default IEx autocompletion
 
-  This modules augments the IEx autocompletion logic to complete file paths in
-  strings. This lets you tab the paths in calls to Toolshed helpers and
-  functions like `File.read/1`.
-  """
+    This modules augments the IEx autocompletion logic to complete file paths in
+    strings. This lets you tab the paths in calls to Toolshed helpers and
+    functions like `File.read/1`.
+    """
 
-  @type result() :: {:yes | :no, charlist(), [charlist()]}
+    @type result() :: {:yes | :no, charlist(), [charlist()]}
 
-  @doc """
-  Handle autocomplete calls
+    @doc """
+    Handle autocomplete calls
 
-  This function handles path autocompletion and if that's not appropriate, it
-  delegates to IEx.Autocomplete for normal completion.
+    This function handles path autocompletion and if that's not appropriate, it
+    delegates to IEx.Autocomplete for normal completion.
 
-  See `set_expand_fun/0` for manual registration.
-  """
-  @spec expand(charlist()) :: result()
-  def expand(expr) do
-    case string_fragment(expr) do
-      [] ->
-        IEx.Autocomplete.expand(expr)
+    See `set_expand_fun/0` for manual registration.
+    """
+    @spec expand(charlist()) :: result()
+    def expand(expr) do
+      case string_fragment(expr) do
+        [] ->
+          IEx.Autocomplete.expand(expr)
 
-      fragment_cl ->
-        fragment = to_string(fragment_cl)
-        possible_paths = find_possible_paths(fragment)
-        expand_path(fragment, possible_paths)
-    end
-  end
-
-  @doc false
-  @spec string_fragment(charlist()) :: charlist()
-  def string_fragment(expr), do: string_fragment(:possible_string, expr, [])
-  defp string_fragment(:assume_not_string, [], acc), do: acc
-
-  defp string_fragment(:assume_not_string, [?" | rest], acc),
-    do: string_fragment(:assume_string, rest, acc)
-
-  defp string_fragment(:assume_not_string, [_ | rest], acc),
-    do: string_fragment(:assume_not_string, rest, acc)
-
-  defp string_fragment(:assume_string, [], _acc), do: []
-
-  defp string_fragment(:assume_string, [?" | rest], acc),
-    do: string_fragment(:assume_not_string, rest, acc)
-
-  defp string_fragment(:assume_string, [_ | rest], acc),
-    do: string_fragment(:assume_string, rest, acc)
-
-  defp string_fragment(:possible_string, [], _acc), do: []
-
-  # Handle escaped double quotes
-  defp string_fragment(:possible_string, [?", ?\\ | rest], acc) do
-    string_fragment(:possible_string, rest, [?\\, ?" | acc])
-  end
-
-  # Don't trigger in a string interpolation
-  defp string_fragment(:possible_string, [?{, ?# | _rest], _acc), do: []
-
-  defp string_fragment(:possible_string, [?" | rest], acc) do
-    string_fragment(:assume_not_string, rest, acc)
-  end
-
-  defp string_fragment(:possible_string, [h | rest], acc) do
-    string_fragment(:possible_string, rest, [h | acc])
-  end
-
-  defp completion_part(already_entered, full_path, dir?) do
-    part = full_path |> String.replace_prefix(already_entered, "") |> to_charlist()
-
-    if dir? do
-      part ++ '/'
-    else
-      part ++ '"'
-    end
-  end
-
-  defp ls_prefix(".") do
-    [
-      ".",
-      ".."
-      | ls_prefix("./.")
-        |> Enum.map(fn "./" <> name -> name end)
-    ]
-  end
-
-  defp ls_prefix("..") do
-    [".."]
-  end
-
-  defp ls_prefix(fragment) do
-    dir = Path.dirname(fragment)
-    prefix = prefix_from_dir(dir, fragment)
-
-    case File.ls(dir) do
-      {:ok, list} ->
-        list
-        |> Enum.map(&Path.join(prefix, &1))
-        |> Enum.filter(&String.starts_with?(&1, fragment))
-
-      _ ->
-        []
-    end
-  end
-
-  # Handle relative path to the current directory
-  defp prefix_from_dir(".", <<c, _::binary>>) when c != ?., do: ""
-  defp prefix_from_dir(dir, _fragment), do: dir
-
-  # Returns possible paths as [{path, dir?}]
-  @doc false
-  @spec find_possible_paths(String.t()) :: [{Path.t(), boolean}]
-  def find_possible_paths(path_fragment) do
-    path_fragment
-    |> ls_prefix()
-    |> Enum.map(fn path -> {path, File.dir?(path)} end)
-  end
-
-  # Look through a list of possible paths for the specified
-  # fragment and return a completion hint and options
-  @doc false
-  @spec expand_path(String.t(), [{Path.t(), boolean()}]) ::
-          {:no, [], []} | {:yes, charlist(), [charlist()]}
-  def expand_path(path_fragment, possible_paths) do
-    expansions =
-      Enum.map(possible_paths, fn {path, dir?} ->
-        {completion_part(path_fragment, path, dir?), to_charlist(Path.basename(path))}
-      end)
-
-    case expansions do
-      [] ->
-        {:no, '', []}
-
-      [{unique, _}] ->
-        {:yes, unique, []}
-
-      list ->
-        {completions, filenames} = Enum.unzip(list)
-        hint = Enum.reduce(completions, &common_prefix/2)
-        {:yes, hint, filenames}
-    end
-  end
-
-  # Find the common prefix for two charlists
-  defp common_prefix(a, b, acc \\ [])
-
-  defp common_prefix([h | t1], [h | t2], acc) do
-    common_prefix(t1, t2, [h | acc])
-  end
-
-  defp common_prefix(_, _, acc) do
-    Enum.reverse(acc)
-  end
-
-  # The following are adapted from IEx.Autocomplete
-
-  # Provides a helper function that is injected into connecting remote nodes to
-  # properly handle autocompletion.
-  @doc false
-  @spec remsh(node()) :: (charlist() -> result())
-  def remsh(node) do
-    fn e ->
-      case :rpc.call(node, Toolshed.Autocomplete, :expand, [e]) do
-        {:badrpc, _} -> {:no, '', []}
-        r -> r
+        fragment_cl ->
+          fragment = to_string(fragment_cl)
+          possible_paths = find_possible_paths(fragment)
+          expand_path(fragment, possible_paths)
       end
     end
-  end
 
-  @doc """
-  Set the IO server's `:expand_fun`
+    @doc false
+    @spec string_fragment(charlist()) :: charlist()
+    def string_fragment(expr), do: string_fragment(:possible_string, expr, [])
+    defp string_fragment(:assume_not_string, [], acc), do: acc
 
-  This is a slightly modified version of `IEx.Autocomplete.set_expand_fun/0` to
-  register the autocompletion logic. It is normally called by `use Toolshed`,
-  but may be called manually as well.
-  """
-  @spec set_expand_fun() :: :ok | {:error, any}
-  def set_expand_fun() do
-    gl = Process.group_leader()
+    defp string_fragment(:assume_not_string, [?" | rest], acc),
+      do: string_fragment(:assume_string, rest, acc)
 
-    expand_fun =
-      if node(gl) != node() do
-        Toolshed.Autocomplete.remsh(node())
+    defp string_fragment(:assume_not_string, [_ | rest], acc),
+      do: string_fragment(:assume_not_string, rest, acc)
+
+    defp string_fragment(:assume_string, [], _acc), do: []
+
+    defp string_fragment(:assume_string, [?" | rest], acc),
+      do: string_fragment(:assume_not_string, rest, acc)
+
+    defp string_fragment(:assume_string, [_ | rest], acc),
+      do: string_fragment(:assume_string, rest, acc)
+
+    defp string_fragment(:possible_string, [], _acc), do: []
+
+    # Handle escaped double quotes
+    defp string_fragment(:possible_string, [?", ?\\ | rest], acc) do
+      string_fragment(:possible_string, rest, [?\\, ?" | acc])
+    end
+
+    # Don't trigger in a string interpolation
+    defp string_fragment(:possible_string, [?{, ?# | _rest], _acc), do: []
+
+    defp string_fragment(:possible_string, [?" | rest], acc) do
+      string_fragment(:assume_not_string, rest, acc)
+    end
+
+    defp string_fragment(:possible_string, [h | rest], acc) do
+      string_fragment(:possible_string, rest, [h | acc])
+    end
+
+    defp completion_part(already_entered, full_path, dir?) do
+      part = full_path |> String.replace_prefix(already_entered, "") |> to_charlist()
+
+      if dir? do
+        part ++ '/'
       else
-        &Toolshed.Autocomplete.expand/1
+        part ++ '"'
       end
+    end
 
-    # expand_fun is not supported by a shell variant
-    # on Windows, so we do two IO calls, not caring
-    # about the result of the expand_fun one.
-    _ = :io.setopts(gl, expand_fun: expand_fun)
-    :io.setopts(gl, binary: true, encoding: :unicode)
+    defp ls_prefix(".") do
+      [
+        ".",
+        ".."
+        | ls_prefix("./.")
+          |> Enum.map(fn "./" <> name -> name end)
+      ]
+    end
+
+    defp ls_prefix("..") do
+      [".."]
+    end
+
+    defp ls_prefix(fragment) do
+      dir = Path.dirname(fragment)
+      prefix = prefix_from_dir(dir, fragment)
+
+      case File.ls(dir) do
+        {:ok, list} ->
+          list
+          |> Enum.map(&Path.join(prefix, &1))
+          |> Enum.filter(&String.starts_with?(&1, fragment))
+
+        _ ->
+          []
+      end
+    end
+
+    # Handle relative path to the current directory
+    defp prefix_from_dir(".", <<c, _::binary>>) when c != ?., do: ""
+    defp prefix_from_dir(dir, _fragment), do: dir
+
+    # Returns possible paths as [{path, dir?}]
+    @doc false
+    @spec find_possible_paths(String.t()) :: [{Path.t(), boolean}]
+    def find_possible_paths(path_fragment) do
+      path_fragment
+      |> ls_prefix()
+      |> Enum.map(fn path -> {path, File.dir?(path)} end)
+    end
+
+    # Look through a list of possible paths for the specified
+    # fragment and return a completion hint and options
+    @doc false
+    @spec expand_path(String.t(), [{Path.t(), boolean()}]) ::
+            {:no, [], []} | {:yes, charlist(), [charlist()]}
+    def expand_path(path_fragment, possible_paths) do
+      expansions =
+        Enum.map(possible_paths, fn {path, dir?} ->
+          {completion_part(path_fragment, path, dir?), to_charlist(Path.basename(path))}
+        end)
+
+      case expansions do
+        [] ->
+          {:no, '', []}
+
+        [{unique, _}] ->
+          {:yes, unique, []}
+
+        list ->
+          {completions, filenames} = Enum.unzip(list)
+          hint = Enum.reduce(completions, &common_prefix/2)
+          {:yes, hint, filenames}
+      end
+    end
+
+    # Find the common prefix for two charlists
+    defp common_prefix(a, b, acc \\ [])
+
+    defp common_prefix([h | t1], [h | t2], acc) do
+      common_prefix(t1, t2, [h | acc])
+    end
+
+    defp common_prefix(_, _, acc) do
+      Enum.reverse(acc)
+    end
+
+    # The following are adapted from IEx.Autocomplete
+
+    # Provides a helper function that is injected into connecting remote nodes to
+    # properly handle autocompletion.
+    @doc false
+    @spec remsh(node()) :: (charlist() -> result())
+    def remsh(node) do
+      fn e ->
+        case :rpc.call(node, Toolshed.Autocomplete, :expand, [e]) do
+          {:badrpc, _} -> {:no, '', []}
+          r -> r
+        end
+      end
+    end
+
+    @doc """
+    Set the IO server's `:expand_fun`
+
+    This is a slightly modified version of `IEx.Autocomplete.set_expand_fun/0` to
+    register the autocompletion logic. It is normally called by `use Toolshed`,
+    but may be called manually as well.
+    """
+    @spec set_expand_fun() :: :ok | {:error, any}
+    def set_expand_fun() do
+      gl = Process.group_leader()
+
+      expand_fun =
+        if node(gl) != node() do
+          Toolshed.Autocomplete.remsh(node())
+        else
+          &Toolshed.Autocomplete.expand/1
+        end
+
+      # expand_fun is not supported by a shell variant
+      # on Windows, so we do two IO calls, not caring
+      # about the result of the expand_fun one.
+      _ = :io.setopts(gl, expand_fun: expand_fun)
+      :io.setopts(gl, binary: true, encoding: :unicode)
+    end
+  end
+else
+  defmodule Toolshed.Autocomplete do
+    @moduledoc """
+    Path autocompletion comes with Elixir now
+    """
+
+    @doc "Path autocomplete comes with Elixir"
+    @spec set_expand_fun() :: :ok
+    def set_expand_fun(), do: :ok
   end
 end

--- a/test/toolshed/autocomplete_test.exs
+++ b/test/toolshed/autocomplete_test.exs
@@ -1,112 +1,114 @@
-defmodule Toolshed.AutocompleteTest do
-  use ExUnit.Case
-  alias Toolshed.Autocomplete
+if Version.match?(System.version(), "< 1.13.0-rc.0") do
+  defmodule Toolshed.AutocompleteTest do
+    use ExUnit.Case
+    alias Toolshed.Autocomplete
 
-  defp sf(string) do
-    string |> to_charlist() |> Enum.reverse() |> Autocomplete.string_fragment()
-  end
-
-  describe "triggers on string fragments" do
-    test "ignores empty strings" do
-      assert sf('') == ''
-      assert sf('"') == ''
+    defp sf(string) do
+      string |> to_charlist() |> Enum.reverse() |> Autocomplete.string_fragment()
     end
 
-    test "ignores things that aren't strings" do
-      assert sf('abc') == ''
+    describe "triggers on string fragments" do
+      test "ignores empty strings" do
+        assert sf('') == ''
+        assert sf('"') == ''
+      end
+
+      test "ignores things that aren't strings" do
+        assert sf('abc') == ''
+      end
+
+      test "triggers on possible strings" do
+        assert sf('"abc') == 'abc'
+        assert sf('"escaped \\" quote') == 'escaped \\" quote'
+        assert sf('File.read("abc') == 'abc'
+        assert sf('File.read("ABCabc123.___') == 'ABCabc123.___'
+        assert sf('File.read("some_file", var') == ''
+        assert sf('File.read("some_file", "string') == 'string'
+      end
+
+      test "ignores string interpolation" do
+        assert sf('"\#{') == ''
+        assert sf('"\#{Fi') == ''
+      end
     end
 
-    test "triggers on possible strings" do
-      assert sf('"abc') == 'abc'
-      assert sf('"escaped \\" quote') == 'escaped \\" quote'
-      assert sf('File.read("abc') == 'abc'
-      assert sf('File.read("ABCabc123.___') == 'ABCabc123.___'
-      assert sf('File.read("some_file", var') == ''
-      assert sf('File.read("some_file", "string') == 'string'
+    describe "find_possible_paths/1" do
+      test "existing absolute paths" do
+        # /usr is a directory in / on OSX and Linux
+        assert {"/usr", true} in Autocomplete.find_possible_paths("/")
+
+        # partial entry
+        assert {"/usr", true} in Autocomplete.find_possible_paths("/u")
+        assert {"/usr", true} in Autocomplete.find_possible_paths("/us")
+        assert {"/usr", true} in Autocomplete.find_possible_paths("/usr")
+        assert {"/usr/bin", true} in Autocomplete.find_possible_paths("/usr/")
+        assert {"/usr/bin", true} in Autocomplete.find_possible_paths("/usr/b")
+        assert {"/usr/bin", true} in Autocomplete.find_possible_paths("/usr/bi")
+        assert {"/usr/bin", true} in Autocomplete.find_possible_paths("/usr/bin")
+      end
+
+      test "bad absolute paths" do
+        assert [] == Autocomplete.find_possible_paths("/nonexistent_dir")
+      end
+
+      test "dot" do
+        paths = Autocomplete.find_possible_paths(".")
+
+        assert {".", true} in paths
+        assert {"..", true} in paths
+        assert {".formatter.exs", false} in paths
+      end
+
+      test "dot dot" do
+        assert [{"..", true}] == Autocomplete.find_possible_paths("..")
+      end
+
+      test "relative paths with the dot" do
+        assert {"./lib", true} in Autocomplete.find_possible_paths("./")
+        assert {"./lib", true} in Autocomplete.find_possible_paths("./l")
+        assert {"./lib", true} in Autocomplete.find_possible_paths("./li")
+        assert {"./lib", true} in Autocomplete.find_possible_paths("./lib")
+        assert {"./lib/toolshed.ex", false} in Autocomplete.find_possible_paths("./lib/")
+        assert {"./lib/toolshed.ex", false} in Autocomplete.find_possible_paths("./lib/t")
+        assert {"./lib/toolshed", true} in Autocomplete.find_possible_paths("./lib/t")
+
+        assert [] == Autocomplete.find_possible_paths("./lib/ttt")
+      end
+
+      test "relative paths without the dot" do
+        assert {"lib", true} in Autocomplete.find_possible_paths("l")
+        assert {"lib", true} in Autocomplete.find_possible_paths("li")
+        assert {"lib", true} in Autocomplete.find_possible_paths("lib")
+        assert {"lib/toolshed", true} in Autocomplete.find_possible_paths("lib/")
+      end
+
+      test "ignores strings with wildcard chars" do
+        # NOTE: the implementation no longer uses Path.wildcard/2
+        assert [] == Autocomplete.find_possible_paths("*")
+        assert [] == Autocomplete.find_possible_paths("/etc/*")
+        assert [] == Autocomplete.find_possible_paths("?i")
+        assert [] == Autocomplete.find_possible_paths("l[a-z]b")
+        assert [] == Autocomplete.find_possible_paths("{lib,test}")
+      end
     end
 
-    test "ignores string interpolation" do
-      assert sf('"\#{') == ''
-      assert sf('"\#{Fi') == ''
-    end
-  end
+    describe "expand_path/2" do
+      test "expands to no options" do
+        assert {:no, [], []} == Autocomplete.expand_path("zzz", [])
+      end
 
-  describe "find_possible_paths/1" do
-    test "existing absolute paths" do
-      # /usr is a directory in / on OSX and Linux
-      assert {"/usr", true} in Autocomplete.find_possible_paths("/")
+      test "expands to one option" do
+        # file expands to final double quote
+        assert {:yes, '23"', []} == Autocomplete.expand_path("1", [{"123", false}])
 
-      # partial entry
-      assert {"/usr", true} in Autocomplete.find_possible_paths("/u")
-      assert {"/usr", true} in Autocomplete.find_possible_paths("/us")
-      assert {"/usr", true} in Autocomplete.find_possible_paths("/usr")
-      assert {"/usr/bin", true} in Autocomplete.find_possible_paths("/usr/")
-      assert {"/usr/bin", true} in Autocomplete.find_possible_paths("/usr/b")
-      assert {"/usr/bin", true} in Autocomplete.find_possible_paths("/usr/bi")
-      assert {"/usr/bin", true} in Autocomplete.find_possible_paths("/usr/bin")
-    end
+        # directory expands to include slash
+        assert {:yes, '23/', []} == Autocomplete.expand_path("1", [{"123", true}])
+      end
 
-    test "bad absolute paths" do
-      assert [] == Autocomplete.find_possible_paths("/nonexistent_dir")
-    end
-
-    test "dot" do
-      paths = Autocomplete.find_possible_paths(".")
-
-      assert {".", true} in paths
-      assert {"..", true} in paths
-      assert {".formatter.exs", false} in paths
-    end
-
-    test "dot dot" do
-      assert [{"..", true}] == Autocomplete.find_possible_paths("..")
-    end
-
-    test "relative paths with the dot" do
-      assert {"./lib", true} in Autocomplete.find_possible_paths("./")
-      assert {"./lib", true} in Autocomplete.find_possible_paths("./l")
-      assert {"./lib", true} in Autocomplete.find_possible_paths("./li")
-      assert {"./lib", true} in Autocomplete.find_possible_paths("./lib")
-      assert {"./lib/toolshed.ex", false} in Autocomplete.find_possible_paths("./lib/")
-      assert {"./lib/toolshed.ex", false} in Autocomplete.find_possible_paths("./lib/t")
-      assert {"./lib/toolshed", true} in Autocomplete.find_possible_paths("./lib/t")
-
-      assert [] == Autocomplete.find_possible_paths("./lib/ttt")
-    end
-
-    test "relative paths without the dot" do
-      assert {"lib", true} in Autocomplete.find_possible_paths("l")
-      assert {"lib", true} in Autocomplete.find_possible_paths("li")
-      assert {"lib", true} in Autocomplete.find_possible_paths("lib")
-      assert {"lib/toolshed", true} in Autocomplete.find_possible_paths("lib/")
-    end
-
-    test "ignores strings with wildcard chars" do
-      # NOTE: the implementation no longer uses Path.wildcard/2
-      assert [] == Autocomplete.find_possible_paths("*")
-      assert [] == Autocomplete.find_possible_paths("/etc/*")
-      assert [] == Autocomplete.find_possible_paths("?i")
-      assert [] == Autocomplete.find_possible_paths("l[a-z]b")
-      assert [] == Autocomplete.find_possible_paths("{lib,test}")
-    end
-  end
-
-  describe "expand_path/2" do
-    test "expands to no options" do
-      assert {:no, [], []} == Autocomplete.expand_path("zzz", [])
-    end
-
-    test "expands to one option" do
-      # file expands to final double quote
-      assert {:yes, '23"', []} == Autocomplete.expand_path("1", [{"123", false}])
-
-      # directory expands to include slash
-      assert {:yes, '23/', []} == Autocomplete.expand_path("1", [{"123", true}])
-    end
-
-    test "expands to hint and options" do
-      assert {:yes, 'bc', ['abcd', 'abce', 'abcf']} ==
-               Autocomplete.expand_path("a", [{"abcd", false}, {"abce", true}, {"abcf", false}])
+      test "expands to hint and options" do
+        assert {:yes, 'bc', ['abcd', 'abce', 'abcf']} ==
+                 Autocomplete.expand_path("a", [{"abcd", false}, {"abce", true}, {"abcf", false}])
+      end
     end
   end
 end


### PR DESCRIPTION
The path completion code was improved and merged into Elixir 1.13 so
it's not needed any more!

This removes it at compile-time so that it's still available for anyone
using Elixir 1.12 and earlier. Elixir 1.13 users get to use the better
built-in code.
