### PR TITLE
Highlight `Toolshed.Unix.grep` output

### DIFF
--- a/lib/toolshed/unix.ex
+++ b/lib/toolshed/unix.ex
@@ -27,12 +27,17 @@ defmodule Toolshed.Unix do
   @doc """
   Run a regular expression on a file and print the matching lines.
 
-  iex> grep ~r/video/, "/etc/mime.types"
+      iex> grep ~r/video/, "/etc/mime.types"
+
+  If colored is enabled for the shell, the matches will be highlighted red.
   """
   @spec grep(Regex.t(), Path.t()) :: :"do not show this result in output"
   def grep(regex, path) do
     File.stream!(path)
     |> Stream.filter(&Regex.match?(regex, &1))
+    |> Stream.map(fn line ->
+      Regex.replace(regex, line, &IO.ANSI.format([:red, &1]))
+    end)
     |> Stream.each(&IO.write/1)
     |> Stream.run()
 

--- a/test/toolshed/unix_test.exs
+++ b/test/toolshed/unix_test.exs
@@ -14,7 +14,7 @@ defmodule Toolshed.UnixTest do
 
   test "grep/2 returns lines of file with given pattern" do
     assert capture_io(fn -> Unix.grep(~r/Content/, "test/support/test_file.doc") end) ==
-             "Content of this will be read for test purposes"
+             "\e[31mContent\e[0m of this will be read for test purposes"
 
     assert capture_io(fn -> Unix.grep(~r/not available/, "test/support/test_file.doc") end) ==
              ""


### PR DESCRIPTION
If ANSI color is enabled, this will format grep results `red` by default.

Otherwise a user can pass in options to alter the grep highlighting as desired