### PR TITLE
Support OTP 25

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,20 +19,9 @@ install_system_deps: &install_system_deps
         apk add build-base libmnl-dev
 
 jobs:
-  build_elixir_1_13_otp_24:
+  build_elixir_1_13_otp_25:
     docker:
-      - image: hexpm/elixir:1.13.0-rc.1-erlang-24.1.5-alpine-3.14.2
-    <<: *defaults
-    steps:
-      - checkout
-      - <<: *install_hex_rebar
-      - <<: *install_system_deps
-      - run: mix deps.get
-      - run: mix test --exclude has_ipv6
-
-  build_elixir_1_12_otp_24:
-    docker:
-      - image: hexpm/elixir:1.12.3-erlang-24.1.5-alpine-3.14.2
+      - image: hexpm/elixir:1.13.4-erlang-25.0-alpine-3.15.4
     <<: *defaults
     steps:
       - checkout
@@ -55,9 +44,31 @@ jobs:
             - _build
             - deps
 
+  build_elixir_1_13_otp_24:
+    docker:
+      - image: hexpm/elixir:1.13.4-erlang-24.3.4-alpine-3.15.3
+    <<: *defaults
+    steps:
+      - checkout
+      - <<: *install_hex_rebar
+      - <<: *install_system_deps
+      - run: mix deps.get
+      - run: mix test --exclude has_ipv6
+
+  build_elixir_1_12_otp_24:
+    docker:
+      - image: hexpm/elixir:1.12.3-erlang-24.3.4-alpine-3.15.3
+    <<: *defaults
+    steps:
+      - checkout
+      - <<: *install_hex_rebar
+      - <<: *install_system_deps
+      - run: mix deps.get
+      - run: mix test --exclude has_ipv6
+
   build_elixir_1_11_otp_23:
     docker:
-      - image: hexpm/elixir:1.11.4-erlang-23.3.4-alpine-3.13.3
+      - image: hexpm/elixir:1.11.4-erlang-23.3.4.13-alpine-3.15.3
     <<: *defaults
     steps:
       - checkout
@@ -107,6 +118,7 @@ workflows:
   version: 2
   build_test:
     jobs:
+      - build_elixir_1_13_otp_25
       - build_elixir_1_13_otp_24
       - build_elixir_1_12_otp_24
       - build_elixir_1_11_otp_23

--- a/lib/toolshed/top/processes.ex
+++ b/lib/toolshed/top/processes.ex
@@ -1,7 +1,7 @@
 defmodule Toolshed.Top.Processes do
   @moduledoc false
 
-  @spec new() :: atom()
+  @spec new() :: :ets.table()
   def new() do
     :ets.new(:toolshed_top, [])
   end

--- a/mix.exs
+++ b/mix.exs
@@ -49,7 +49,7 @@ defmodule Toolshed.MixProject do
 
   defp dialyzer() do
     [
-      flags: [:race_conditions, :unmatched_returns, :error_handling, :underspecs],
+      flags: [:missing_return, :extra_return, :unmatched_returns, :error_handling, :underspecs],
       plt_add_apps: [:iex, :nerves_runtime, :inets]
     ]
   end


### PR DESCRIPTION
* remove deprecated `:race_conditions` dialyzer option
* Add new `:missing_return` and `:extra_return` dialyzer options
* Update Elixir/Erlang CI versions