### PR TITLE
Improve weather/0

### DIFF
--- a/lib/toolshed.ex
+++ b/lib/toolshed.ex
@@ -71,6 +71,7 @@ defmodule Toolshed do
       import Toolshed.History, only: [history: 0, history: 1]
       import Toolshed.Log, only: [log_attach: 0, log_attach: 1, log_detach: 0]
       import Toolshed.TCPPing, only: [tping: 1, tping: 2, ping: 1, ping: 2]
+      import Toolshed.Weather
 
       # If module docs have been stripped, then don't tell the user that they can
       # see them.

--- a/lib/toolshed/http.ex
+++ b/lib/toolshed/http.ex
@@ -3,22 +3,7 @@ defmodule Toolshed.HTTP do
   Helpers that make HTTP requests
   """
 
-  @doc """
-  Display the local weather
-
-  See http://wttr.in/:help for more information.
-  """
-  @spec weather() :: :"do not show this result in output"
-  def weather() do
-    check_app(:inets)
-    check_app(:ssl)
-
-    {:ok, {_status, _headers, body}} =
-      :httpc.request(:get, {'https://v2.wttr.in/?An0', []}, [ssl: [verify: :verify_none]], [])
-
-    body |> :binary.list_to_bin() |> IO.puts()
-    IEx.dont_display_result()
-  end
+  import Toolshed.Utils, only: [check_app: 1]
 
   @doc """
   Generate an ASCII art QR code
@@ -130,20 +115,6 @@ defmodule Toolshed.HTTP do
 
       other ->
         IO.puts("other message: #{inspect(other)}")
-    end
-  end
-
-  defp check_app(app) do
-    case Application.ensure_all_started(app) do
-      {:ok, _} ->
-        :ok
-
-      {:error, _} ->
-        raise RuntimeError, """
-        #{inspect(app)} can't be started.
-        This probably means that it isn't in the OTP release.
-        To fix, edit your mix.exs and add #{inspect(app)} to the :extra_applications list.
-        """
     end
   end
 end

--- a/lib/toolshed/utils.ex
+++ b/lib/toolshed/utils.ex
@@ -1,0 +1,19 @@
+defmodule Toolshed.Utils do
+  @moduledoc false
+
+  @doc false
+  @spec check_app(atom) :: :ok
+  def check_app(app) do
+    case Application.ensure_all_started(app) do
+      {:ok, _} ->
+        :ok
+
+      {:error, _} ->
+        raise RuntimeError, """
+        #{inspect(app)} can't be started.
+        This probably means that it isn't in the OTP release.
+        To fix, edit your mix.exs and add #{inspect(app)} to the :extra_applications list.
+        """
+    end
+  end
+end

--- a/lib/toolshed/weather.ex
+++ b/lib/toolshed/weather.ex
@@ -1,0 +1,38 @@
+defmodule Toolshed.Weather do
+  @moduledoc """
+  This module provides the `weather` command
+  """
+
+  import Toolshed.Utils, only: [check_app: 1]
+
+  @weather_url 'https://v2.wttr.in/?An0'
+
+  @doc """
+  Display the local weather
+
+  See http://wttr.in/:help for more information.
+  """
+  @spec weather() :: :"do not show this result in output"
+  def weather() do
+    check_app(:inets)
+    check_app(:ssl)
+
+    {:ok, {_status, _headers, body}} =
+      :httpc.request(:get, {@weather_url, []}, [ssl: [verify: :verify_none]], [])
+
+    body |> :binary.list_to_bin() |> IO.puts()
+    IEx.dont_display_result()
+  rescue
+    # unexpected response
+    _ in MatchError ->
+      raise RuntimeError, """
+      Something went wrong when making an HTTP request.
+      """
+  catch
+    # :httpc server crashed
+    :exit, _ ->
+      raise RuntimeError, """
+      Something went wrong when making an HTTP request.
+      """
+  end
+end

--- a/lib/toolshed/weather.ex
+++ b/lib/toolshed/weather.ex
@@ -17,22 +17,28 @@ defmodule Toolshed.Weather do
     check_app(:inets)
     check_app(:ssl)
 
-    {:ok, {_status, _headers, body}} =
-      :httpc.request(:get, {@weather_url, []}, [ssl: [verify: :verify_none]], [])
-
-    body |> :binary.list_to_bin() |> IO.puts()
+    get_weather() |> IO.puts()
     IEx.dont_display_result()
-  rescue
-    # unexpected response
-    _ in MatchError ->
-      raise RuntimeError, """
-      Something went wrong when making an HTTP request.
-      """
+  end
+
+  @doc false
+  @spec get_weather() :: binary
+  def get_weather() do
+    case :httpc.request(:get, {@weather_url, []}, [ssl: [verify: :verify_none]], []) do
+      {:ok, {_status, _headers, body}} ->
+        body |> :binary.list_to_bin()
+
+      {:error, reason} ->
+        """
+        Something went wrong when making an HTTP request.
+        #{inspect(reason)}
+        """
+    end
   catch
-    # :httpc server crashed
-    :exit, _ ->
-      raise RuntimeError, """
+    :exit, reason ->
+      """
       Something went wrong when making an HTTP request.
+      #{inspect(reason)}
       """
   end
 end

--- a/test/toolshed/http_test.exs
+++ b/test/toolshed/http_test.exs
@@ -11,10 +11,6 @@ defmodule Toolshed.HTTPTest do
            end) =~ "Toolshed aims to improve the Elixir shell"
   end
 
-  test "weather/0 returns correct value" do
-    assert Toolshed.HTTP.weather() == :"do not show this result in output"
-  end
-
   test "qr_encode/1 returns correct value" do
     assert Toolshed.HTTP.qr_encode("Nerves") == :"do not show this result in output"
   end

--- a/test/toolshed/weather_test.exs
+++ b/test/toolshed/weather_test.exs
@@ -1,0 +1,12 @@
+defmodule Toolshed.WeatherTest do
+  use ExUnit.Case
+  import ExUnit.CaptureIO
+  import Toolshed.Weather
+
+  test "weather/0 ensures :inets and :ssl are started" do
+    Application.stop(:inets)
+    Application.stop(:ssl)
+
+    assert weather() == :"do not show this result in output"
+  end
+end

--- a/test/toolshed/weather_test.exs
+++ b/test/toolshed/weather_test.exs
@@ -1,6 +1,5 @@
 defmodule Toolshed.WeatherTest do
   use ExUnit.Case
-  import ExUnit.CaptureIO
   import Toolshed.Weather
 
   test "weather/0 ensures :inets and :ssl are started" do


### PR DESCRIPTION
@fhunleth I tentatively prototyped https://github.com/elixir-toolshed/toolshed/issues/125 with https://github.com/elixir-toolshed/toolshed/issues/60 in mind.

### Changes

- extract `weather/0` command from `Toolshed.HTTP`, newly creating `Toolshed.Weather`
- extract `check_app/1` helper from `Toolshed.HTTP`, newly creating `Toolshed.Utils`
- catch `:exit` signal that potentially occurs when `:httpc` server crashes
- rescue unexpected responses

### Notes

- I was able to recreate two types of potential errors on my local machine
  - `:https` server crashing, which throws `:exit`
  - `:https` responds with unexpected response, which is currently anything but `{:ok, {_, _, _}}`
- I have trouble wording errors so it would be great if you come up with better messages.
- resolves https://github.com/elixir-toolshed/toolshed/issues/125



