### PR TITLE
Do delegation to make all function available from top-level Toolshed

### DIFF
--- a/lib/toolshed.ex
+++ b/lib/toolshed.ex
@@ -46,20 +46,8 @@ defmodule Toolshed do
   """
 
   defmacro __using__(_) do
-    nerves =
-      if Code.ensure_loaded?(Toolshed.Nerves) do
-        quote do
-          import Toolshed.Nerves
-        end
-      else
-        quote do
-        end
-      end
-
     quote do
       import Toolshed
-
-      unquote(nerves)
 
       # If module docs have been stripped, then don't tell the user that they can
       # see them.
@@ -113,9 +101,7 @@ defmodule Toolshed do
 
   defdelegate cat(path), to: Toolshed.Unix
   defdelegate date(), to: Toolshed.Date
-  defdelegate dmesg(), to: Toolshed.Nerves
   defdelegate exit(), to: Toolshed.Misc
-  defdelegate fw_validate(), to: Toolshed.Nerves
   defdelegate grep(regex, path), to: Toolshed.Unix
   defdelegate history(), to: Toolshed.History
   defdelegate hostname(), to: Toolshed.Net
@@ -124,21 +110,27 @@ defmodule Toolshed do
   defdelegate load_term!(path), to: Toolshed.Misc
   defdelegate log_attach(options), to: Toolshed.Log
   defdelegate log_detach(), to: Toolshed.Log
-  defdelegate lsmod(), to: Toolshed.Nerves
   defdelegate lsof(), to: Toolshed.Lsof
   defdelegate lsusb(), to: Toolshed.HW
   defdelegate multicast_addresses(), to: Toolshed.Multicast
   defdelegate nslookup(name), to: Toolshed.Net
   defdelegate ping(address, options), to: Toolshed.TCPPing
   defdelegate qr_encode(message), to: Toolshed.HTTP
-  defdelegate reboot!(), to: Toolshed.Nerves
-  defdelegate reboot(), to: Toolshed.Nerves
   defdelegate save_term!(term, path), to: Toolshed.Misc
   defdelegate save_value(value, path, inspect_opts), to: Toolshed.Misc
   defdelegate top(), to: Toolshed.Top
   defdelegate tping(address, options), to: Toolshed.TCPPing
   defdelegate tree(), to: Toolshed.Unix
-  defdelegate uname(), to: Toolshed.Nerves
   defdelegate uptime(), to: Toolshed.Unix
   defdelegate weather(), to: Toolshed.Weather
+
+  # Nerves-specific functions
+  if Code.ensure_loaded?(Nerves.Runtime) do
+    defdelegate dmesg(), to: Toolshed.Nerves
+    defdelegate fw_validate(), to: Toolshed.Nerves
+    defdelegate lsmod(), to: Toolshed.Nerves
+    defdelegate reboot!(), to: Toolshed.Nerves
+    defdelegate reboot(), to: Toolshed.Nerves
+    defdelegate uname(), to: Toolshed.Nerves
+  end
 end

--- a/lib/toolshed.ex
+++ b/lib/toolshed.ex
@@ -22,7 +22,7 @@ defmodule Toolshed do
     * `httpget/2`      - print or download the results of a HTTP GET request
     * `hostname/0`     - print our hostname
     * `ifconfig/0`     - print info on network interfaces
-    * `load_term!/2`   - load a term that was saved by `save_term/2`
+    * `load_term!/1`   - load a term that was saved by `save_term/2`
     * `log_attach/1`   - send log messages to the current group leader
     * `log_detach/0`   - stop sending log messages to the current group leader
     * `lsof/0`         - print out open file handles by OS process
@@ -34,7 +34,7 @@ defmodule Toolshed do
     * `qr_encode/1`    - create a QR code (requires networking)
     * `reboot/0`       - reboots gracefully (Nerves-only)
     * `reboot!/0`      - reboots immediately  (Nerves-only)
-    * `save_value/2`   - save a value to a file as Elixir terms (uses inspect)
+    * `save_value/3`   - save a value to a file as Elixir terms (uses inspect)
     * `save_term!/2`   - save a term as a binary
     * `top/2`          - list out the top processes
     * `tping/2`        - check if a host can be reached (like ping, but uses TCP)
@@ -58,20 +58,8 @@ defmodule Toolshed do
 
     quote do
       import Toolshed
-      import Toolshed.Top
-      import Toolshed.Lsof
+
       unquote(nerves)
-      import Toolshed.Unix
-      import Toolshed.Net
-      import Toolshed.Misc
-      import Toolshed.HW
-      import Toolshed.HTTP
-      import Toolshed.Multicast
-      import Toolshed.Date, only: [date: 0]
-      import Toolshed.History, only: [history: 0, history: 1]
-      import Toolshed.Log, only: [log_attach: 0, log_attach: 1, log_detach: 0]
-      import Toolshed.TCPPing, only: [tping: 1, tping: 2, ping: 1, ping: 2]
-      import Toolshed.Weather
 
       # If module docs have been stripped, then don't tell the user that they can
       # see them.
@@ -122,4 +110,35 @@ defmodule Toolshed do
   def hex(value) do
     inspect(value, base: :hex)
   end
+
+  defdelegate cat(path), to: Toolshed.Unix
+  defdelegate date(), to: Toolshed.Date
+  defdelegate dmesg(), to: Toolshed.Nerves
+  defdelegate exit(), to: Toolshed.Misc
+  defdelegate fw_validate(), to: Toolshed.Nerves
+  defdelegate grep(regex, path), to: Toolshed.Unix
+  defdelegate history(), to: Toolshed.History
+  defdelegate hostname(), to: Toolshed.Net
+  defdelegate httpget(url, options), to: Toolshed.HTTP
+  defdelegate ifconfig(), to: Toolshed.Net
+  defdelegate load_term!(path), to: Toolshed.Misc
+  defdelegate log_attach(options), to: Toolshed.Log
+  defdelegate log_detach(), to: Toolshed.Log
+  defdelegate lsmod(), to: Toolshed.Nerves
+  defdelegate lsof(), to: Toolshed.Lsof
+  defdelegate lsusb(), to: Toolshed.HW
+  defdelegate multicast_addresses(), to: Toolshed.Multicast
+  defdelegate nslookup(name), to: Toolshed.Net
+  defdelegate ping(address, options), to: Toolshed.TCPPing
+  defdelegate qr_encode(message), to: Toolshed.HTTP
+  defdelegate reboot!(), to: Toolshed.Nerves
+  defdelegate reboot(), to: Toolshed.Nerves
+  defdelegate save_term!(term, path), to: Toolshed.Misc
+  defdelegate save_value(value, path, inspect_opts), to: Toolshed.Misc
+  defdelegate top(), to: Toolshed.Top
+  defdelegate tping(address, options), to: Toolshed.TCPPing
+  defdelegate tree(), to: Toolshed.Unix
+  defdelegate uname(), to: Toolshed.Nerves
+  defdelegate uptime(), to: Toolshed.Unix
+  defdelegate weather(), to: Toolshed.Weather
 end

--- a/test/toolshed_test.exs
+++ b/test/toolshed_test.exs
@@ -2,13 +2,11 @@ defmodule ToolshedTest do
   use ExUnit.Case
   import ExUnit.CaptureIO
 
-  @expected_public_functions [
+  @generic_functions [
     cat: 1,
     cmd: 1,
     date: 0,
-    dmesg: 0,
     exit: 0,
-    fw_validate: 0,
     grep: 2,
     hex: 1,
     history: 0,
@@ -18,30 +16,35 @@ defmodule ToolshedTest do
     load_term!: 1,
     log_attach: 1,
     log_detach: 0,
-    lsmod: 0,
     lsof: 0,
     lsusb: 0,
     multicast_addresses: 0,
     nslookup: 1,
     ping: 2,
     qr_encode: 1,
-    reboot: 0,
-    reboot!: 0,
     save_term!: 2,
     save_value: 3,
     top: 0,
     tping: 2,
     tree: 0,
-    uname: 0,
     uptime: 0,
     weather: 0
   ]
-  test "public functions" do
-    actual_public_functions = Toolshed.__info__(:functions)
 
-    for f <- @expected_public_functions do
-      assert f in actual_public_functions
-    end
+  @nerves_specific_functions [
+    dmesg: 0,
+    fw_validate: 0,
+    lsmod: 0,
+    reboot: 0,
+    reboot!: 0,
+    uname: 0
+  ]
+
+  test "public functions" do
+    expected = @generic_functions ++ @nerves_specific_functions
+    actual = Toolshed.__info__(:functions)
+
+    for f <- expected, do: assert(f in actual)
   end
 
   test "cmd/1 normal printable chars" do

--- a/test/toolshed_test.exs
+++ b/test/toolshed_test.exs
@@ -2,6 +2,48 @@ defmodule ToolshedTest do
   use ExUnit.Case
   import ExUnit.CaptureIO
 
+  @expected_public_functions [
+    cat: 1,
+    cmd: 1,
+    date: 0,
+    dmesg: 0,
+    exit: 0,
+    fw_validate: 0,
+    grep: 2,
+    hex: 1,
+    history: 0,
+    hostname: 0,
+    httpget: 2,
+    ifconfig: 0,
+    load_term!: 1,
+    log_attach: 1,
+    log_detach: 0,
+    lsmod: 0,
+    lsof: 0,
+    lsusb: 0,
+    multicast_addresses: 0,
+    nslookup: 1,
+    ping: 2,
+    qr_encode: 1,
+    reboot: 0,
+    reboot!: 0,
+    save_term!: 2,
+    save_value: 3,
+    top: 0,
+    tping: 2,
+    tree: 0,
+    uname: 0,
+    uptime: 0,
+    weather: 0
+  ]
+  test "public functions" do
+    actual_public_functions = Toolshed.__info__(:functions)
+
+    for f <- @expected_public_functions do
+      assert f in actual_public_functions
+    end
+  end
+
   test "cmd/1 normal printable chars" do
     assert capture_io(fn ->
              Toolshed.cmd("printf \"hello, world\"")


### PR DESCRIPTION
### Description

This pull request resolves https://github.com/elixir-toolshed/toolshed/issues/131, also https://github.com/elixir-toolshed/toolshed/issues/58.

### Changes

- Do delegation instead of importing sub directory functions
- Test all the public functions are accessible via `Toolshed` module

### Testing in local IEx

When `Nerves.Runtime` is loaded, Nerves-specific functions are loaded.

![](https://user-images.githubusercontent.com/7563926/176899866-c9e23d32-1637-42e9-8ac5-025d6ea4f324.png)

In the generic Elixir environment, Nerves-specific functions are not loaded.

![](https://user-images.githubusercontent.com/7563926/176899883-7f3418d1-c9e9-4f8e-8d70-84140a737713.png)

### Testing the Hex docs

The API reference will look like this.

![](https://user-images.githubusercontent.com/7563926/176900889-61e8181e-d0cc-46b5-89a1-1241b2eae879.png)

