### PR TITLE
Inspect bits

### DIFF
--- a/lib_src/core/inspect_bits.ex
+++ b/lib_src/core/inspect_bits.ex
@@ -1,0 +1,116 @@
+defmodule Toolshed.Core.InspectBits do
+  @type conversion :: %{
+          :binary => binary(),
+          :decimal => binary(),
+          :hex => binary(),
+          :octal => binary()
+        }
+
+  @doc """
+  Prints out information on the given numeric value.
+  """
+  @spec inspect_bits(integer | binary) :: :"do not show this result in output"
+  def inspect_bits(number) do
+    conversion = convert_bits(number)
+
+    [
+      [:cyan, "Decimal    ", :reset, " : ", conversion.decimal],
+      [:cyan, "Hexadecimal", :reset, " : ", conversion.hex],
+      [:cyan, "Octal      ", :reset, " : ", conversion.octal],
+      [:cyan, "Binary     ", :reset, " : ", format_base2_string(conversion.binary)]
+    ]
+    |> Enum.map(&IO.ANSI.format(&1))
+    |> Enum.intersperse('\n')
+    |> IO.puts()
+
+    IEx.dont_display_result()
+  end
+
+  @doc """
+  Converts a given number to different representations.
+  """
+  @spec convert_bits(integer | binary) :: conversion
+  def convert_bits(number) when is_binary(number) do
+    number |> parse_numeric_string() |> convert_bits()
+  end
+
+  def convert_bits(number) when is_integer(number) do
+    %{
+      decimal: integer_to_string(number, :decimal),
+      binary: integer_to_string(number, :binary),
+      octal: integer_to_string(number, :octal),
+      hex: integer_to_string(number, :hex)
+    }
+  end
+
+  defp integer_to_string(number, :hex) when is_integer(number) do
+    "0x" <> value = inspect(number, base: :hex)
+    value
+  end
+
+  defp integer_to_string(number, :octal) when is_integer(number) do
+    "0o" <> value = inspect(number, base: :octal)
+    value
+  end
+
+  defp integer_to_string(number, :binary) when is_integer(number) do
+    "0b" <> value = inspect(number, base: :binary)
+    value
+  end
+
+  defp integer_to_string(number, _) when is_integer(number) do
+    to_string(number)
+  end
+
+  defp parse_numeric_string("0x" <> hex) do
+    case Integer.parse(hex, 16) do
+      {value, _} -> value
+      _ -> nil
+    end
+  end
+
+  defp parse_numeric_string("0o" <> octal) do
+    case Integer.parse(octal, 8) do
+      {value, _} -> value
+      _ -> nil
+    end
+  end
+
+  defp parse_numeric_string("0b" <> binary) do
+    case Integer.parse(binary, 2) do
+      {value, _} -> value
+      _ -> nil
+    end
+  end
+
+  defp parse_numeric_string(decimal) when is_binary(decimal) do
+    case Integer.parse(decimal, 10) do
+      {value, _} -> value
+      _ -> nil
+    end
+  end
+
+  defp format_base2_string(base2_string) when is_binary(base2_string) do
+    string_length = String.length(base2_string)
+
+    byte_count =
+      if rem(string_length, 8) == 0 do
+        div(string_length, 8)
+      else
+        div(string_length, 8) + 1
+      end
+
+    String.pad_leading(base2_string, byte_count * 8, "0")
+    |> to_charlist
+    |> Enum.chunk_every(8)
+    |> Enum.intersperse(' | ')
+    |> Enum.map(fn byte ->
+      byte
+      |> Enum.chunk_by(fn bit -> bit == ?1 end)
+      |> Enum.map(fn
+        [?1 | _] = chunk -> [:green, chunk]
+        chunk -> [:white, chunk]
+      end)
+    end)
+  end
+end

--- a/test/toolshed/inspect_bits_test.exs
+++ b/test/toolshed/inspect_bits_test.exs
@@ -1,0 +1,43 @@
+defmodule Toolshed.InspectBitsTest do
+  use ExUnit.Case
+  import ExUnit.CaptureIO
+
+  test "inspect_bits/1 prints information on number" do
+    assert capture_io(fn -> Toolshed.inspect_bits(19_075_645) end) ==
+             """
+             \e[36mDecimal    \e[0m : 19075645\e[0m
+             \e[36mHexadecimal\e[0m : 123123D\e[0m
+             \e[36mOctal      \e[0m : 110611075\e[0m
+             \e[36mBinary     \e[0m : \e[37m0000000\e[32m1\e[37m | \e[37m00\e[32m1\e[37m000\e[32m11\e[37m | \e[37m000\e[32m1\e[37m00\e[32m1\e[37m0\e[37m | \e[37m00\e[32m1111\e[37m0\e[32m1\e[0m
+             """
+
+    assert Toolshed.inspect_bits(19_075_645) == :"do not show this result in output"
+  end
+
+  @expected_conversion_table %{
+    decimal: "19075645",
+    hex: "123123D",
+    octal: "110611075",
+    binary: "1001000110001001000111101"
+  }
+
+  test "convert_bits/1 with integer" do
+    assert Toolshed.convert_bits(19_075_645) == @expected_conversion_table
+  end
+
+  test "convert_bits/1 with base 10 string" do
+    assert Toolshed.convert_bits("19075645") == @expected_conversion_table
+  end
+
+  test "convert_bits/1 with base 16 string" do
+    assert Toolshed.convert_bits("0x123123D") == @expected_conversion_table
+  end
+
+  test "convert_bits/1 with base 8 string" do
+    assert Toolshed.convert_bits("0o110611075") == @expected_conversion_table
+  end
+
+  test "convert_bits/1 with base 2 string" do
+    assert Toolshed.convert_bits("0b1001000110001001000111101") == @expected_conversion_table
+  end
+end

--- a/test/toolshed_test.exs
+++ b/test/toolshed_test.exs
@@ -5,6 +5,7 @@ defmodule ToolshedTest do
   @core_helpers [
     cat: 1,
     cmd: 1,
+    convert_bits: 1,
     date: 0,
     grep: 2,
     hex: 1,
@@ -14,6 +15,7 @@ defmodule ToolshedTest do
     httpget: 1,
     httpget: 2,
     ifconfig: 0,
+    inspect_bits: 1,
     load_term!: 1,
     log_attach: 0,
     log_attach: 1,


### PR DESCRIPTION
An attempt at https://github.com/elixir-toolshed/toolshed/issues/38

![](https://user-images.githubusercontent.com/7563926/177019105-a792065e-fae3-4ec2-8348-dcff5426034f.png)

### Notes

- resolves https://github.com/elixir-toolshed/toolshed/issues/38
- I was stuck in naming the function; the C program https://github.com/mellowcandle/bitwise does bitwise operations so bitwise as a name makes sense but the functionality we need is more about inspecting a number because Elixir can do math.