### PR TITLE
Copy function docs to Toolshed; hide submodules

### DIFF
--- a/lib/toolshed.ex
+++ b/lib/toolshed.ex
@@ -99,39 +99,299 @@ defmodule Toolshed do
     inspect(value, base: :hex)
   end
 
+  @doc """
+  Reads and prints out the contents of a file
+  """
   defdelegate cat(path), to: Toolshed.Cat
+
+  @doc """
+  Return the date and time in UTC
+  """
   defdelegate date(), to: Toolshed.Date
+
+  @doc """
+  Run a regular expression on a file and print the matching lines.
+
+      iex> grep ~r/video/, "/etc/mime.types"
+
+  If colored is enabled for the shell, the matches will be highlighted red.
+  """
   defdelegate grep(regex, path), to: Toolshed.Grep
+
+  @doc """
+  Print out the IEx shell history
+
+  The default is to print the history from the current group leader, but
+  any group leader can be passed in if desired.
+  """
   defdelegate history(), to: Toolshed.History
+
+  @doc """
+  Return the hostname
+
+  ## Examples
+
+      iex> hostname
+      "nerves-1234"
+  """
   defdelegate hostname(), to: Toolshed.Hostname
+
+  @doc """
+  Perform a HTTP GET request for the specified URL
+
+  By default, the results are printed or you can optionally choose to download
+  it to a specific location on the file system.
+
+  Options:
+
+  * `:dest` - File path to write the response to. Defaults to printing to the terminal.
+  * `:verbose` - Display request and response headers. Disabled by default.
+  """
   defdelegate httpget(url, options \\ []), to: Toolshed.HTTP
+
+  @doc """
+  Print out the network interfaces and their addresses.
+  """
   defdelegate ifconfig(), to: Toolshed.Ifconfig
+
+  @doc """
+  Load an Erlang term from the filesystem.
+
+  ## Examples
+
+      iex> save_term!({:some_interesting_atom, ["some", "list"]}, "/root/some_atom.term")
+      {:some_interesting_atom, ["some", "list"]}
+      iex> load_term!("/root/some_atom.term")
+      {:some_interesting_atom, ["some", "list"]}
+  """
   defdelegate load_term!(path), to: Toolshed.Misc
+
+  @doc """
+  Attach the current session to the Elixir logger
+
+  This forwards incoming log messages to the terminal. Call `detach/0` to stop
+  the messages.
+
+  Behind the scenes, this uses Elixir's built-in console logger and can be
+  configured similarly. See the [Logger console backend
+  documentation](https://hexdocs.pm/logger/Logger.html#module-console-backend)
+  for details. The following are useful options:
+
+  * `:level` - the minimum log level to report. E.g., specify `level: :warning`
+    to only see warnings and errors.
+  * `:metadata` - a list of metadata keys to show or `:all`
+
+  Unspecified options use either the console backend's default or those found
+  in the application environment for the `:console` Logger backend.
+  """
   defdelegate log_attach(options \\ []), to: Toolshed.Log
+
+  @doc """
+  Detach the current session from the Elixir logger
+  """
   defdelegate log_detach(), to: Toolshed.Log
+
+  @doc """
+  List out open files by process
+
+  This is an simple version of lsof that works on Linux and
+  Nerves. While running the normal version of lsof provides
+  more information, this can be convenient when lsof isn't
+  easily available or can't be run due to `:emfile` errors
+  from starting port processes due to too many files being open..
+  """
   defdelegate lsof(), to: Toolshed.Lsof
+
+  @doc """
+  Print out information on all of the connected USB devices.
+  """
   defdelegate lsusb(), to: Toolshed.Lsusb
+
+  @doc """
+  List all active multicast addresses
+
+  This lists out multicast addresses by network interface
+  similar to `ip maddr show`. It currently only works on
+  Linux.
+  """
   defdelegate multicast_addresses(), to: Toolshed.Multicast
+
+  @doc """
+  Lookup the specified hostname in the DNS and print out the addresses.
+
+  ## Examples
+
+      iex> nslookup "google.com"
+      Name:     google.com
+      Address:  172.217.7.238
+      Address:  2607:f8b0:4004:804::200e
+  """
   defdelegate nslookup(name), to: Toolshed.Nslookup
+
+  @doc """
+  Ping an IP address using TCP
+
+  This tries to connect to the remote host using TCP instead of sending an ICMP
+  echo request like normal ping. This made it possible to write in pure Elixir.
+
+  NOTE: Specifying an `:ifname` only sets the source IP address for the TCP
+  connection. This is only a hint to use the specified interface and not a
+  guarantee. For example, if you have two interfaces on the same LAN, the OS
+  routing tables may send traffic out one interface in preference to the one
+  that you want. On Linux, you can enable policy-based routing and add source
+  routes to guarantee that packets go out the desired interface.
+
+  Options:
+
+  * `:ifname` - Specify a network interface to use. (e.g., "eth0")
+  * `:port` - Which TCP port to try (defaults to 80)
+
+  ## Examples
+
+      iex> ping "nerves-project.org"
+      Press enter to stop
+      Response from nerves-project.org (185.199.108.153:80): time=4.155ms
+      Response from nerves-project.org (185.199.108.153:80): time=10.385ms
+      Response from nerves-project.org (185.199.108.153:80): time=12.458ms
+
+      iex> ping "google.com", ifname: "wlp5s0"
+      Press enter to stop
+      Response from google.com (172.217.7.206:80): time=88.602ms
+  """
   defdelegate ping(address, options \\ []), to: Toolshed.Ping
+
+  @doc """
+  Generate an ASCII art QR code
+
+  See https://github.com/chubin/qrenco.de for more information.
+  """
   defdelegate qr_encode(message), to: Toolshed.HTTP
+
+  @doc """
+  Save an Erlang term to the filesystem for easy loading later
+
+  This function returns the `value` passed in to allow easy piping.
+
+  ## Examples
+
+      iex> :sys.get_state(MyServer) |> save_term!("/root/my_server.term")
+      # Reboot board
+      iex> :sys.replace_state(&load_term!("/root/my_server.term"))
+  """
   defdelegate save_term!(term, path), to: Toolshed.Misc
+
+  @doc """
+  Save a value to a file as Elixir terms
+
+  ## Examples
+
+      # Save the contents of SystemRegistry to a file
+      iex> SystemRegistry.match(:_) |> save_value("/root/sr.txt")
+      :ok
+  """
   defdelegate save_value(value, path, inspect_opts \\ []), to: Toolshed.Misc
+
+  @doc """
+  Interactively show the top Elixir processes
+
+  This is intended to be called from the IEx prompt and will periodically
+  update the console with the top processes. Press enter to exit.
+
+  Options:
+
+  * `:order` - the sort order for the results (`:reductions`, `:delta_reductions`,
+    `:mailbox`, `:delta_mailbox`, `:total_heap_size`, `:delta_total_heap_size`, `:heap_size`,
+    `:delta_heap_size`, `:stack_size`, `:delta_stack_size`)
+  """
   defdelegate top(), to: Toolshed.Top
+
+  @doc """
+  Check if a computer is up using TCP.
+
+  Options:
+
+  * `:ifname` - Specify a network interface to use. (e.g., "eth0")
+  * `:port` - Which TCP port to try (defaults to 80)
+
+  ## Examples
+
+      iex> tping "nerves-project.org"
+      Response from nerves-project.org (185.199.108.153:80): time=4.155ms
+
+      iex> tping "192.168.1.1"
+      Response from 192.168.1.1 (192.168.1.1:80): time=1.227ms
+  """
   defdelegate tping(address, options \\ []), to: Toolshed.Tping
+
+  @doc """
+  Print out directories and files in tree form.
+  """
   defdelegate tree(), to: Toolshed.Tree
+
+  @doc """
+  Print out the current uptime.
+  """
   defdelegate uptime(), to: Toolshed.Uptime
+
+  @doc """
+  Display the local weather
+
+  See http://wttr.in/:help for more information.
+  """
   defdelegate weather(), to: Toolshed.Weather
 
   # Nerves-specific functions
   if Code.ensure_loaded?(Nerves.Runtime) do
+    @doc """
+    Print out kernel log messages
+    """
     defdelegate dmesg(), to: Toolshed.Nerves
+
+    @doc """
+    Exit the current IEx session
+    """
     defdelegate exit(), to: Toolshed.Nerves
+
+    @doc """
+    Validate a firmware image
+
+    All official Nerves Systems automatically validate newly installed firmware.
+    For some systems, it's possible to disable this so that new firmware gets
+    one chance to boot. If it's not "validated" before a reboot, then the device
+    reverts to the old firmware.
+    """
     defdelegate fw_validate(), to: Toolshed.Nerves
+
+    @doc """
+    Print out the loaded kernel modules
+
+    Aside from printing out whether the kernel has been tainted, the
+    Linux utility of the same name just dump the contents of "/proc/modules"
+    like this one.
+
+    Some kernel modules may be built-in to the kernel image. To see
+    those, run `cat "/lib/modules/x.y.z/modules.builtin"` where `x.y.z` is
+    the kernel's version number.
+    """
     defdelegate lsmod(), to: Toolshed.Nerves
+
+    @doc """
+    Reboot immediately without a graceful shutdown. This is for the impatient.
+    """
     @spec reboot!() :: no_return()
     defdelegate reboot!(), to: Toolshed.Nerves
+
+    @doc """
+    Shortcut to reboot a board. This is a graceful reboot, so it takes some time
+    before the real reboot.
+    """
     defdelegate reboot(), to: Toolshed.Nerves
+
+    @doc """
+    Print out information about the running software
+
+    This is similar to the Linux `uname` to help people remember what to type.
+    """
     defdelegate uname(), to: Toolshed.Nerves
   end
 end

--- a/lib/toolshed/autocomplete.ex
+++ b/lib/toolshed/autocomplete.ex
@@ -2,13 +2,13 @@
 # longer needed.
 if Version.match?(System.version(), "< 1.13.0-rc.0") do
   defmodule Toolshed.Autocomplete do
-    @moduledoc """
-    Add path completion to the default IEx autocompletion
+    @moduledoc false
 
-    This modules augments the IEx autocompletion logic to complete file paths in
-    strings. This lets you tab the paths in calls to Toolshed helpers and
-    functions like `File.read/1`.
-    """
+    # Add path completion to the default IEx autocompletion
+    #
+    # This modules augments the IEx autocompletion logic to complete file paths in
+    # strings. This lets you tab the paths in calls to Toolshed helpers and
+    # functions like `File.read/1`.
 
     @type result() :: {:yes | :no, charlist(), [charlist()]}
 
@@ -199,9 +199,7 @@ if Version.match?(System.version(), "< 1.13.0-rc.0") do
   end
 else
   defmodule Toolshed.Autocomplete do
-    @moduledoc """
-    Path autocompletion comes with Elixir now
-    """
+    @moduledoc false
 
     @doc "Path autocomplete comes with Elixir"
     @spec set_expand_fun() :: :ok

--- a/lib/toolshed/cat.ex
+++ b/lib/toolshed/cat.ex
@@ -1,7 +1,5 @@
 defmodule Toolshed.Cat do
-  @moduledoc """
-  This module provides the `cat` command
-  """
+  @moduledoc false
 
   @doc """
   Reads and prints out the contents of a file

--- a/lib/toolshed/date.ex
+++ b/lib/toolshed/date.ex
@@ -1,7 +1,5 @@
 defmodule Toolshed.Date do
-  @moduledoc """
-  This module provides the `date` command
-  """
+  @moduledoc false
 
   @doc """
   Return the date and time in UTC

--- a/lib/toolshed/grep.ex
+++ b/lib/toolshed/grep.ex
@@ -1,7 +1,5 @@
 defmodule Toolshed.Grep do
-  @moduledoc """
-  This module provides the `grep` command
-  """
+  @moduledoc false
 
   @doc """
   Run a regular expression on a file and print the matching lines.

--- a/lib/toolshed/hostname.ex
+++ b/lib/toolshed/hostname.ex
@@ -1,7 +1,5 @@
 defmodule Toolshed.Hostname do
-  @moduledoc """
-  This module provides the `hostname` command
-  """
+  @moduledoc false
 
   require Record
 

--- a/lib/toolshed/http.ex
+++ b/lib/toolshed/http.ex
@@ -1,7 +1,5 @@
 defmodule Toolshed.HTTP do
-  @moduledoc """
-  Helpers that make HTTP requests
-  """
+  @moduledoc false
 
   import Toolshed.Utils, only: [check_app: 1]
 

--- a/lib/toolshed/ifconfig.ex
+++ b/lib/toolshed/ifconfig.ex
@@ -1,7 +1,5 @@
 defmodule Toolshed.Ifconfig do
-  @moduledoc """
-  This module provides the `ifconfig` command
-  """
+  @moduledoc false
 
   @doc """
   Print out the network interfaces and their addresses.

--- a/lib/toolshed/log.ex
+++ b/lib/toolshed/log.ex
@@ -1,11 +1,10 @@
 defmodule Toolshed.Log do
-  @moduledoc """
-  Utilities for attaching and detaching to the log
-
-  These utilities configure Elixir's console backend to attach
-  to the current group leader. This makes it work over `ssh` sessions
-  and play well with the IEx prompt.
-  """
+  @moduledoc false
+  # Utilities for attaching and detaching to the log
+  #
+  # These utilities configure Elixir's console backend to attach
+  # to the current group leader. This makes it work over `ssh` sessions
+  # and play well with the IEx prompt.
 
   @doc """
   Attach the current session to the Elixir logger

--- a/lib/toolshed/lsof.ex
+++ b/lib/toolshed/lsof.ex
@@ -1,7 +1,5 @@
 defmodule Toolshed.Lsof do
-  @moduledoc """
-  List out open files by process
-  """
+  @moduledoc false
 
   @doc """
   List out open files by process

--- a/lib/toolshed/lsusb.ex
+++ b/lib/toolshed/lsusb.ex
@@ -1,7 +1,5 @@
 defmodule Toolshed.Lsusb do
-  @moduledoc """
-  This module provides the `lsusb` command
-  """
+  @moduledoc false
 
   @doc """
   Print out information on all of the connected USB devices.

--- a/lib/toolshed/misc.ex
+++ b/lib/toolshed/misc.ex
@@ -1,7 +1,6 @@
 defmodule Toolshed.Misc do
-  @moduledoc """
-  Miscellaneous helpers
-  """
+  @moduledoc false
+  # Miscellaneous helpers
 
   @doc """
   Save a value to a file as Elixir terms

--- a/lib/toolshed/multicast.ex
+++ b/lib/toolshed/multicast.ex
@@ -1,7 +1,6 @@
 defmodule Toolshed.Multicast do
-  @moduledoc """
-  Multicast utilities
-  """
+  @moduledoc false
+  # Multicast utilities
 
   @doc """
   List all active multicast addresses

--- a/lib/toolshed/nerves.ex
+++ b/lib/toolshed/nerves.ex
@@ -1,18 +1,7 @@
 if Code.ensure_loaded?(Nerves.Runtime) do
   defmodule Toolshed.Nerves do
-    @moduledoc """
-    Helpers that are useful on Nerves devices
-
-    Helpers include:
-
-    * `dmesg/0`        - print kernel messages
-    * `exit/0`         - exit the current IEx session
-    * `fw_validate/0`  - marks the current image as valid (check Nerves system if supported)
-    * `lsmod/0`        - print out what kernel modules have been loaded
-    * `reboot/0`       - reboots gracefully
-    * `reboot!/0`      - reboots immediately
-    * `uname/0`        - print information about the running system
-    """
+    @moduledoc false
+    # Helpers that are useful on Nerves devices
 
     alias Nerves.Runtime.KV
 

--- a/lib/toolshed/nslookup.ex
+++ b/lib/toolshed/nslookup.ex
@@ -1,7 +1,5 @@
 defmodule Toolshed.Nslookup do
-  @moduledoc """
-  This module provides the `nslookup` command
-  """
+  @moduledoc false
 
   require Record
 

--- a/lib/toolshed/ping.ex
+++ b/lib/toolshed/ping.ex
@@ -1,7 +1,5 @@
 defmodule Toolshed.Ping do
-  @moduledoc """
-  This module provides the `ping` command
-  """
+  @moduledoc false
 
   @doc """
   Ping an IP address using TCP

--- a/lib/toolshed/top.ex
+++ b/lib/toolshed/top.ex
@@ -1,7 +1,5 @@
 defmodule Toolshed.Top do
-  @moduledoc """
-  Find the top processes
-  """
+  @moduledoc false
 
   alias Toolshed.Top.Server
 

--- a/lib/toolshed/tping.ex
+++ b/lib/toolshed/tping.ex
@@ -1,7 +1,5 @@
 defmodule Toolshed.Tping do
-  @moduledoc """
-  This module provides the `tping` command
-  """
+  @moduledoc false
 
   require Record
 

--- a/lib/toolshed/tree.ex
+++ b/lib/toolshed/tree.ex
@@ -1,7 +1,5 @@
 defmodule Toolshed.Tree do
-  @moduledoc """
-  This module provides the `tree` command
-  """
+  @moduledoc false
 
   @doc """
   Print out directories and files in tree form.

--- a/lib/toolshed/uptime.ex
+++ b/lib/toolshed/uptime.ex
@@ -1,7 +1,5 @@
 defmodule Toolshed.Uptime do
-  @moduledoc """
-  This module provides the `tree` command
-  """
+  @moduledoc false
 
   @doc """
   Print out the current uptime.

--- a/lib/toolshed/weather.ex
+++ b/lib/toolshed/weather.ex
@@ -1,7 +1,5 @@
 defmodule Toolshed.Weather do
-  @moduledoc """
-  This module provides the `weather` command
-  """
+  @moduledoc false
 
   import Toolshed.Utils, only: [check_app: 1]
 


### PR DESCRIPTION
Currently `h/1` helper does not show useful info for individual functions due to delegation (https://github.com/elixir-toolshed/toolshed/pull/132). Here is one proposal to improve docs.

Alternative solution:  https://github.com/elixir-toolshed/toolshed/pull/141

### Changes

- add function docs to all the delegation definitions
- hide submodules

### Outcome

Running `h/1`

![](https://user-images.githubusercontent.com/7563926/177043389-772c40b5-e653-4257-ae9b-739c191bf7f9.png)

All the submodules are hidden from the package users now that all the info is in the top-level module.

![](https://user-images.githubusercontent.com/7563926/177043388-74eab8f4-627f-4a66-94cf-f5025b40cb00.png)

### Notes

- one disadvantage of this approach is that function docs are located away from implementation
- maybe we can justify it by seeing the top-level module as centralized public docs as opposed to private docs in the other modules 🤔 
