### PR TITLE
Add custom `h/1` macro so that it prints docs for delegated functions

### DIFF
--- a/lib/toolshed.ex
+++ b/lib/toolshed.ex
@@ -47,7 +47,9 @@ defmodule Toolshed do
 
   defmacro __using__(_) do
     quote do
+      import IEx.Helpers, except: [h: 1]
       import Toolshed
+      require Toolshed
 
       # If module docs have been stripped, then don't tell the user that they can
       # see them.
@@ -66,6 +68,20 @@ defmodule Toolshed do
         " imported.",
         help_text
       ])
+    end
+  end
+
+  defmacro h(term) do
+    quote do
+      case unquote(IEx.Introspection.decompose(term, __CALLER__)) do
+        {Toolshed, f} ->
+          f_module = f |> Atom.to_string() |> Macro.camelize()
+          delegate = {Module.concat(Toolshed, f_module), f}
+          IEx.Introspection.h(delegate)
+
+        other ->
+          IEx.Introspection.h(other)
+      end
     end
   end
 

--- a/test/toolshed_test.exs
+++ b/test/toolshed_test.exs
@@ -58,4 +58,21 @@ defmodule ToolshedTest do
              Toolshed.cmd("printf '\\x0'")
            end) == <<0>>
   end
+
+  test "h/1 macro prints doc" do
+    use Toolshed
+
+    assert capture_io(fn ->
+             h(weather)
+           end) == """
+           \e[0m\n\e[7m\e[33m                                 def weather()                                  \e[0m
+           \e[0m
+             \e[36m@spec\e[0m weather() :: :\"do not show this result in output\"
+
+           Display the local weather
+           \e[0m
+           See http://wttr.in/:help for more information.
+           \e[0m
+           """
+  end
 end


### PR DESCRIPTION
Currently `h/1` helper does not show useful info for individual functions due to delegation (https://github.com/elixir-toolshed/toolshed/pull/132). 

per discussed with @fhunleth

#### before
<img width="800" src="https://user-images.githubusercontent.com/7563926/188517185-7bbc163b-b724-4b6e-bb50-1693dc526d92.png">

#### after
<img width="800" src="https://user-images.githubusercontent.com/7563926/188517191-bf9d1d2d-a519-488f-9192-27cf27d57d19.png">

