### PR TITLE
Forward h/1 help and hide from exdoc

### DIFF
--- a/lib/toolshed.ex
+++ b/lib/toolshed.ex
@@ -71,17 +71,23 @@ defmodule Toolshed do
     end
   end
 
+  @doc false
   defmacro h(term) do
     quote do
-      case unquote(IEx.Introspection.decompose(term, __CALLER__)) do
-        {Toolshed, f} ->
-          f_module = f |> Atom.to_string() |> Macro.camelize()
-          delegate = {Module.concat(Toolshed, f_module), f}
-          IEx.Introspection.h(delegate)
+      target =
+        case unquote(IEx.Introspection.decompose(term, __CALLER__)) do
+          {Toolshed, :h} ->
+            {Toolshed, :h}
 
-        other ->
-          IEx.Introspection.h(other)
-      end
+          {Toolshed, f} ->
+            f_module = f |> Atom.to_string() |> Macro.camelize()
+            {Module.concat(Toolshed, f_module), f}
+
+          other ->
+            other
+        end
+
+      IEx.Introspection.h(target)
     end
   end
 


### PR DESCRIPTION
Since Toolshed is being sneaky with its `h/1` enhancements, make it show
the `h/1` help that IEx provides already.
