### PR TITLE
Remove most module docs

### DIFF
--- a/lib/toolshed/cat.ex
+++ b/lib/toolshed/cat.ex
@@ -1,7 +1,5 @@
 defmodule Toolshed.Cat do
-  @moduledoc """
-  This module provides the `cat` command
-  """
+  @moduledoc ""
 
   @doc """
   Reads and prints out the contents of a file

--- a/lib/toolshed/date.ex
+++ b/lib/toolshed/date.ex
@@ -1,7 +1,5 @@
 defmodule Toolshed.Date do
-  @moduledoc """
-  This module provides the `date` command
-  """
+  @moduledoc ""
 
   @doc """
   Return the date and time in UTC

--- a/lib/toolshed/grep.ex
+++ b/lib/toolshed/grep.ex
@@ -1,7 +1,5 @@
 defmodule Toolshed.Grep do
-  @moduledoc """
-  This module provides the `grep` command
-  """
+  @moduledoc ""
 
   @doc """
   Run a regular expression on a file and print the matching lines.

--- a/lib/toolshed/history.ex
+++ b/lib/toolshed/history.ex
@@ -1,5 +1,5 @@
 defmodule Toolshed.History do
-  @moduledoc false
+  @moduledoc ""
 
   @doc """
   Print out the IEx shell history

--- a/lib/toolshed/hostname.ex
+++ b/lib/toolshed/hostname.ex
@@ -1,7 +1,5 @@
 defmodule Toolshed.Hostname do
-  @moduledoc """
-  This module provides the `hostname` command
-  """
+  @moduledoc ""
 
   require Record
 

--- a/lib/toolshed/http.ex
+++ b/lib/toolshed/http.ex
@@ -1,7 +1,5 @@
 defmodule Toolshed.HTTP do
-  @moduledoc """
-  Helpers that make HTTP requests
-  """
+  @moduledoc ""
 
   import Toolshed.Utils, only: [check_app: 1]
 

--- a/lib/toolshed/ifconfig.ex
+++ b/lib/toolshed/ifconfig.ex
@@ -1,7 +1,5 @@
 defmodule Toolshed.Ifconfig do
-  @moduledoc """
-  This module provides the `ifconfig` command
-  """
+  @moduledoc ""
 
   @doc """
   Print out the network interfaces and their addresses.

--- a/lib/toolshed/lsof.ex
+++ b/lib/toolshed/lsof.ex
@@ -1,7 +1,5 @@
 defmodule Toolshed.Lsof do
-  @moduledoc """
-  List out open files by process
-  """
+  @moduledoc ""
 
   @doc """
   List out open files by process

--- a/lib/toolshed/lsusb.ex
+++ b/lib/toolshed/lsusb.ex
@@ -1,7 +1,5 @@
 defmodule Toolshed.Lsusb do
-  @moduledoc """
-  This module provides the `lsusb` command
-  """
+  @moduledoc ""
 
   @doc """
   Print out information on all of the connected USB devices.

--- a/lib/toolshed/nslookup.ex
+++ b/lib/toolshed/nslookup.ex
@@ -1,7 +1,5 @@
 defmodule Toolshed.Nslookup do
-  @moduledoc """
-  This module provides the `nslookup` command
-  """
+  @moduledoc ""
 
   require Record
 

--- a/lib/toolshed/ping.ex
+++ b/lib/toolshed/ping.ex
@@ -1,7 +1,5 @@
 defmodule Toolshed.Ping do
-  @moduledoc """
-  This module provides the `ping` command
-  """
+  @moduledoc ""
 
   @doc """
   Ping an IP address using TCP

--- a/lib/toolshed/top.ex
+++ b/lib/toolshed/top.ex
@@ -1,7 +1,5 @@
 defmodule Toolshed.Top do
-  @moduledoc """
-  Find the top processes
-  """
+  @moduledoc ""
 
   alias Toolshed.Top.Server
 

--- a/lib/toolshed/tping.ex
+++ b/lib/toolshed/tping.ex
@@ -1,7 +1,5 @@
 defmodule Toolshed.Tping do
-  @moduledoc """
-  This module provides the `tping` command
-  """
+  @moduledoc ""
 
   require Record
 

--- a/lib/toolshed/tree.ex
+++ b/lib/toolshed/tree.ex
@@ -1,7 +1,5 @@
 defmodule Toolshed.Tree do
-  @moduledoc """
-  This module provides the `tree` command
-  """
+  @moduledoc ""
 
   @doc """
   Print out directories and files in tree form.

--- a/lib/toolshed/uptime.ex
+++ b/lib/toolshed/uptime.ex
@@ -1,7 +1,5 @@
 defmodule Toolshed.Uptime do
-  @moduledoc """
-  This module provides the `tree` command
-  """
+  @moduledoc ""
 
   @doc """
   Print out the current uptime.

--- a/lib/toolshed/weather.ex
+++ b/lib/toolshed/weather.ex
@@ -1,7 +1,5 @@
 defmodule Toolshed.Weather do
-  @moduledoc """
-  This module provides the `weather` command
-  """
+  @moduledoc ""
 
   import Toolshed.Utils, only: [check_app: 1]
 


### PR DESCRIPTION
We'd like to discourage users from calling functions outside of the
`Toolshed` module. However, we'd also like to have the documentation for
the helper functions exist with the implementation. We can do that for
`h/1`, but not with `ex_doc`. Since `ex_doc` will give lots of warnings
for `@moduledoc false`, just leave it blank. The real documentation
should be on the function anyway.
