### PR TITLE
Print nothing when used with quiet option

### DIFF
--- a/lib/toolshed.ex
+++ b/lib/toolshed.ex
@@ -45,29 +45,33 @@ defmodule Toolshed do
 
   """
 
-  defmacro __using__(_) do
+  defmacro __using__(opts \\ []) do
     quote do
       import IEx.Helpers, except: [h: 1]
       import Toolshed
       require Toolshed
 
-      # If module docs have been stripped, then don't tell the user that they can
-      # see them.
-      help_text =
-        case Code.fetch_docs(Toolshed) do
-          {:error, _anything} -> ""
-          _ -> " Run h(Toolshed) for more info."
-        end
+      unless unquote(opts[:quiet]) do
+        # If module docs have been stripped, then don't tell the user that they can
+        # see them.
+        help_text =
+          case Code.fetch_docs(Toolshed) do
+            {:error, _anything} -> ""
+            _ -> " Run h(Toolshed) for more info."
+          end
 
-      Toolshed.Autocomplete.set_expand_fun()
+        Toolshed.Autocomplete.set_expand_fun()
 
-      IO.puts([
-        IO.ANSI.color(:rand.uniform(231) + 1),
-        "Toolshed",
-        IO.ANSI.reset(),
-        " imported.",
-        help_text
-      ])
+        IO.puts([
+          IO.ANSI.color(:rand.uniform(231) + 1),
+          "Toolshed",
+          IO.ANSI.reset(),
+          " imported.",
+          help_text
+        ])
+      end
+
+      :ok
     end
   end
 

--- a/test/toolshed_test.exs
+++ b/test/toolshed_test.exs
@@ -58,4 +58,13 @@ defmodule ToolshedTest do
              Toolshed.cmd("printf '\\x0'")
            end) == <<0>>
   end
+
+  test "__using__ prints help text by default" do
+    assert capture_io(fn -> use Toolshed end) =~
+             "Toolshed\e[0m imported. Run h(Toolshed) for more info"
+  end
+
+  test "__using__ with quiet option prints nothing" do
+    assert capture_io(fn -> use Toolshed, quiet: true end) == ""
+  end
 end


### PR DESCRIPTION
This is a preparation for PR https://github.com/elixir-toolshed/toolshed/pull/157

This pull request allows users to optionally suppress help text that gets printed by default.

<img width="458" src="https://user-images.githubusercontent.com/7563926/193957536-7a69f2e4-a1a0-4c34-b4c9-eefa8850ce7a.png">

### Changes

- Wrap the printing logic in `unless unquote(opts[:quiet]) do ... end`, without changing the logic