### PR TITLE
Rescue httpc's internal MatchError

### DIFF
--- a/lib/toolshed/weather.ex
+++ b/lib/toolshed/weather.ex
@@ -27,16 +27,18 @@ defmodule Toolshed.Weather do
         body |> :binary.list_to_bin()
 
       {:error, reason} ->
-        """
-        Something went wrong when making an HTTP request.
-        #{inspect(reason)}
-        """
+        error_message(reason)
     end
+  rescue
+    e in MatchError -> error_message(e)
   catch
-    :exit, reason ->
-      """
-      Something went wrong when making an HTTP request.
-      #{inspect(reason)}
-      """
+    :exit, reason -> error_message(reason)
+  end
+
+  defp error_message(reason) do
+    """
+    Something went wrong when making an HTTP request.
+    #{inspect(reason)}
+    """
   end
 end


### PR DESCRIPTION
### Description

This is a minor improvement for handling unexpected errors running `weather` command.

Currently when the Internet connection is not available, `httpc` seems to cause this internal `MatchError`, which looks cryptic from the user perspective.

![](https://user-images.githubusercontent.com/7563926/210890620-7852667d-7f28-4b61-b4c9-e1ea9c31ffa7.png)

We can rescue it and control what to show for this error.

![](https://user-images.githubusercontent.com/7563926/210890626-7e576f81-aea6-451e-b7a1-95be685e6c86.png)

### Notes

- Related https://github.com/elixir-toolshed/toolshed/pull/130


