### PR TITLE
Add a simple speed test

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Here's a sample list of helpers:
 * `ping` and `tcping` - check if a remote host is using ICMP or TCP
 * `ifconfig` - list network interfaces
 * `weather` - get the current weather from [wttr.in](https://wttr.in/)
+* `speed_test` - run a simple speed test to guage network throughput
 * `top` - get a list of the top processes and their OTP applications based on
   CPU and memory
 * `tree` - list directory contents as a tree

--- a/lib_src/core/speed_test.ex
+++ b/lib_src/core/speed_test.ex
@@ -1,0 +1,158 @@
+defmodule Toolshed.Core.SpeedTest do
+  @typedoc "Options for speed_test/1"
+  @type speed_test_options :: [
+          duration: pos_integer(),
+          ifname: String.t(),
+          url: String.t() | URI.t()
+        ]
+
+  @doc """
+  Perform a download speed test
+
+  Calling this with no options measures the download speed of a small test
+  file. The test file may not be large enough or close enough to you to
+  produce a good measurement. To fix this, pass a `:url` to a better file. To
+  change the default, add the following to your application environment:
+
+  ```elixir
+  config :toolshed, speed_test_url: "http://my_company.com/speed_test_file.bin"
+  ```
+
+  Commercial users are encouraged to specify their own files to minimize our
+  bandwidth costs.
+
+  Please be aware that this function is somewhat simplistic in how it measures
+  download performance.
+
+  Options:
+
+  * `:duration` - Maximum duration in milliseconds (defaults to 5 seconds)
+  * `:ifname` - Interface to use (e.g., `"wwan0"` or `"eth0"`)
+  * `:url` - File to download for the test
+  """
+  @spec speed_test(speed_test_options()) :: :ok
+  def speed_test(options \\ []) do
+    default_url = Application.get_env(:toolshed, :speed_test_url)
+    url = Keyword.get(options, :url, default_url) |> URI.parse()
+    duration = Keyword.get(options, :duration, 5000)
+
+    request = [
+      ["GET ", url.path, " HTTP/1.1\r\n"],
+      ["Host: ", url.host, "\r\n"],
+      "User-Agent: Mozilla/5.0\r\n",
+      "\r\n",
+      "\r\n"
+    ]
+
+    connect_options =
+      case Keyword.fetch(options, :ifname) do
+        {:ok, ifname} ->
+          [ip: ifname_to_ip(ifname, :inet)]
+
+        :error ->
+          []
+      end
+
+    case :gen_tcp.connect(
+           String.to_charlist(url.host),
+           url.port,
+           [:binary, {:active, true} | connect_options],
+           min(5000, duration)
+         ) do
+      {:ok, s} ->
+        :ok = :gen_tcp.send(s, request)
+        wait_for_connect(s, duration)
+        :gen_tcp.close(s)
+
+      {:error, reason} ->
+        IO.puts("Can't connect to #{url.host}: #{inspect(reason)}")
+    end
+  end
+
+  defp wait_for_connect(s, duration) do
+    receive do
+      {:tcp, ^s, response} ->
+        length = get_length_from_headers(response)
+        start_us = System.monotonic_time(:microsecond)
+        state = %{s: s, start_us: start_us, end_us: start_us + duration * 1000, length: length}
+        loop(state, 0, start_us)
+
+      other ->
+        IO.inspect(other)
+    after
+      5000 ->
+        IO.puts("Can't connect to download site")
+    end
+  end
+
+  defp get_length_from_headers(data) do
+    # Split off the beginning of the content
+    [header, content] = String.split(data, "\r\n\r\n", parts: 2)
+
+    case Regex.run(~r/Content-Length: (\d+)/, header) do
+      [_, content_length] -> String.to_integer(content_length) - byte_size(content)
+      _ -> 0
+    end
+  end
+
+  defp loop(%{length: length} = state, received, _next_status_us) when received >= length do
+    now = System.monotonic_time(:microsecond)
+    print_report(state, received, now)
+  end
+
+  defp loop(state, received, next_status_us) do
+    s = state.s
+
+    receive do
+      {:tcp, ^s, data} ->
+        new_received = received + byte_size(data)
+
+        now = System.monotonic_time(:microsecond)
+        next_status_us = update_status(state, new_received, now, next_status_us)
+
+        if now < state.end_us do
+          loop(state, new_received, next_status_us)
+        else
+          print_report(state, new_received, now)
+        end
+
+      {:tcp_closed, ^s} ->
+        now = System.monotonic_time(:microsecond)
+        print_report(state, received, now)
+
+      other ->
+        IO.inspect(other)
+    after
+      5000 ->
+        IO.puts("Timed out waiting for a response")
+    end
+  end
+
+  defp print_report(state, received, now) do
+    delta_s = max(now - state.start_us, 1) / 1_000_000
+    bps = received * 8 / delta_s
+
+    IO.puts([
+      "\r#{received} bytes received in #{Float.round(delta_s, 2)} s\n",
+      "Download speed: ",
+      format(bps)
+    ])
+  end
+
+  defp update_status(_state, _received, now, next_status_us) when now < next_status_us do
+    next_status_us
+  end
+
+  defp update_status(state, received, now, next_status_us) do
+    delta_us = now - state.start_us
+    bps = received * 8 * 1.0e6 / delta_us
+    ["\r-->  ", format(bps), "  "] |> IO.write()
+
+    next_status_us + 1_000_000
+  end
+
+  defp format(speed) when speed > 1.0e9, do: "#{Float.round(speed / 1.0e9, 2)} Gbps"
+  defp format(speed) when speed > 1.0e6, do: "#{Float.round(speed / 1.0e6, 2)} Mbps"
+  defp format(speed) when speed > 1.0e3, do: "#{Float.round(speed / 1.0e3, 2)} Kbps"
+  defp format(speed), do: "#{round(speed)} bps"
+end

--- a/mix.exs
+++ b/mix.exs
@@ -26,7 +26,10 @@ defmodule Toolshed.MixProject do
   end
 
   def application do
-    [extra_applications: [:iex, :logger]]
+    [
+      env: [speed_test_url: "http://dl.nerves-project.org/speed_test/10MB.bin"],
+      extra_applications: [:iex, :logger]
+    ]
   end
 
   defp deps do

--- a/test/toolshed/speed_test_test.exs
+++ b/test/toolshed/speed_test_test.exs
@@ -1,0 +1,29 @@
+defmodule Toolshed.SpeedTestTest do
+  use ExUnit.Case
+  import ExUnit.CaptureIO
+
+  test "default URL" do
+    assert capture_io(fn ->
+             Toolshed.speed_test(duration: 500)
+           end) =~ "Download speed: "
+  end
+
+  test "passing a bad URL returns an nxdomain error" do
+    assert capture_io(fn ->
+             Toolshed.speed_test(
+               url: "http://does_not_exist.nerves-project.org/file.bin",
+               duration: 500
+             )
+           end) =~ "Can't connect to does_not_exist.nerves-project.org: :nxdomain"
+  end
+
+  test "passing a zero-length file still works" do
+    # nerves-project.org only serves https, so this should be 0 bytes.
+    assert capture_io(fn ->
+             Toolshed.speed_test(
+               url: "http://nerves-project.org/index.html",
+               duration: 500
+             )
+           end) =~ "0 bytes received in 0.0 s\nDownload speed: 0 bps"
+  end
+end

--- a/test/toolshed_test.exs
+++ b/test/toolshed_test.exs
@@ -29,6 +29,8 @@ defmodule ToolshedTest do
     save_term!: 2,
     save_value: 2,
     save_value: 3,
+    speed_test: 0,
+    speed_test: 1,
     top: 0,
     top: 1,
     tcping: 1,


### PR DESCRIPTION
This checks how fast it can download a big file from dl.nerves-project.org or how much it can download in 5 seconds. It's not the best speed test, but it can give a quick idea whether the connection is terrible or not. This originates out of a speed test that we've been using at work.

Options to the speed test include specifying a different URL (both as an option and via application environment so users can default to a self-hosted file), specifying an ifname, and specifying a different max duration.

[![asciicast](https://asciinema.org/a/m1RjXPWfsTw8jpVws6gtzKB5z.svg)](https://asciinema.org/a/m1RjXPWfsTw8jpVws6gtzKB5z)