### PR TITLE
Add `qr_encode_wifi`

### DIFF
--- a/lib_src/core/qr_encode.ex
+++ b/lib_src/core/qr_encode.ex
@@ -14,13 +14,29 @@ defmodule Toolshed.Core.QrEncode do
     {:ok, {_status, _headers, body}} =
       :httpc.request(
         :post,
-        {'http://qrenco.de/', [{'User-Agent', 'curl'}], 'application/x-www-form-urlencoded',
-         form_data},
+        {~c"http://qrenco.de/", [{~c"User-Agent", ~c"curl"}],
+         ~c"application/x-www-form-urlencoded", form_data},
         [],
         []
       )
 
     body |> :binary.list_to_bin() |> IO.puts()
     IEx.dont_display_result()
+  end
+
+  @doc """
+  Generate an ASCII art QR code for WiFi connections
+
+  See https://en.wikipedia.org/wiki/QR_code#Joining_a_Wi%E2%80%91Fi_network
+  for string format
+  """
+  @type wifi_opt :: {:hidden, boolean()} | {:type, :WPA | :WEP | :nopass}
+  @spec qr_encode_wifi(String.t(), String.t(), [wifi_opt()]) ::
+          :"do not show this result in output"
+  def qr_encode_wifi(ssid, psk, opts \\ []) do
+    type = opts[:type] || "WPA"
+    hidden = opts[:hidden] || false
+    msg = "WIFI:S:#{ssid};T:#{type};P:#{psk};H:#{hidden};;"
+    qr_encode(msg)
   end
 end

--- a/test/toolshed/qr_encode_test.exs
+++ b/test/toolshed/qr_encode_test.exs
@@ -4,4 +4,9 @@ defmodule Toolshed.QrEncodeTest do
   test "qr_encode/1 returns correct value" do
     assert Toolshed.qr_encode("Nerves") == :"do not show this result in output"
   end
+
+  test "qr_encode_wifi/3 returns correct value" do
+    assert Toolshed.qr_encode_wifi("NervesSSID", "NervesIsCool", hidden: false, type: :WPA) ==
+             :"do not show this result in output"
+  end
 end

--- a/test/toolshed_test.exs
+++ b/test/toolshed_test.exs
@@ -26,6 +26,8 @@ defmodule ToolshedTest do
     ping: 1,
     ping: 2,
     qr_encode: 1,
+    qr_encode_wifi: 2,
+    qr_encode_wifi: 3,
     save_term!: 2,
     save_value: 2,
     save_value: 3,


### PR DESCRIPTION
Simple helper to format WiFi credentials with QR code formats which can be used on mobile devices to directly connect

![IMG_4046](https://github.com/elixir-toolshed/toolshed/assets/11321326/10e47ad0-d2ca-4c57-906e-baddc139bc00)
