### PR TITLE
Add a fake shell command to avoid using cmd all the time

### DIFF
--- a/lib/toolshed.ex
+++ b/lib/toolshed.ex
@@ -22,6 +22,7 @@ defmodule Toolshed do
     * `date/0`         - print out the current date and time
     * `dmesg/0`        - print kernel messages (Nerves-only)
     * `exit/0`         - exit out of an IEx session
+    * `fake_shell/0`   - starts a sh like session that sends all lines to `cmd/1`
     * `fw_validate/0`  - marks the current image as valid (check Nerves system if supported)
     * `geo/1`          - print out a rough physical location
     * `grep/2`         - print out lines that match a regular expression

--- a/lib_src/core/fake_shell.ex
+++ b/lib_src/core/fake_shell.ex
@@ -1,12 +1,18 @@
+# SPDX-FileCopyrightText: 2025 Marc Lainez
+#
+# SPDX-License-Identifier: Apache-2.0
+#
 defmodule Toolshed.Core.FakeShell do
-  @moduledoc """
-  Provides a small interactive fake shell used in tests and local development.
+  @prompt "fksh> "
 
-  The shell reads lines from `IO.gets/1` and delegates command execution
-  to `Toolshed.cmd/1`. It is intended for manual use or lightweight
-  integration testing where an interactive prompt is convenient.
+  @doc """
+  Start an interactive fake shell session.
 
-    Example
+  The shell reads lines from `IO.gets/1` and delegates command execution to
+  `Toolshed.cmd/1`. It is intended for manual use or lightweight integration
+  testing where an interactive prompt is convenient.
+
+   Example
 
       iex> Toolshed.fake_shell()
       Starting fake shell. Type 'exit' to quit.
@@ -15,24 +21,15 @@ defmodule Toolshed.Core.FakeShell do
 
   The function returns `:ok` when the user types `exit`.
   """
-
-  @prompt "fksh> "
-
-  @doc """
-  Start an interactive fake shell session.
-
-  The function prints a short banner then enters a read-execute loop.
-  Each non-empty line is passed to `Toolshed.cmd/1`. Type `"exit"` to end the session. The function returns `:ok` on exit.
-  """
   @spec fake_shell() :: :ok
   def fake_shell() do
     IO.puts("Starting fake shell. Type 'exit' to quit.")
-    loop()
+    fake_shell_loop()
   end
 
-  defp loop do
+  defp fake_shell_loop() do
     case IO.gets(@prompt) do
-      nil ->
+      :eof ->
         :ok
 
       "exit\n" ->
@@ -43,18 +40,17 @@ defmodule Toolshed.Core.FakeShell do
         |> String.trim()
         |> exec()
 
-        loop()
+        fake_shell_loop()
     end
   end
 
   defp exec(""), do: :ok
 
   defp exec(cmdline) do
-    try do
-      Toolshed.cmd(cmdline)
-    rescue
-      e ->
-        IO.puts("error: #{inspect(e)}")
-    end
+    _ = Toolshed.cmd(cmdline)
+    :ok
+  rescue
+    e ->
+      IO.puts("error: #{inspect(e)}")
   end
 end

--- a/lib_src/core/fake_shell.ex
+++ b/lib_src/core/fake_shell.ex
@@ -13,7 +13,7 @@ defmodule Toolshed.Core.FakeShell do
       fksh> echo hello
       ...
 
-  The function returns `:ok` when the user types `exit` or when EOF is received.
+  The function returns `:ok` when the user types `exit`.
   """
 
   @prompt "fksh> "
@@ -22,8 +22,7 @@ defmodule Toolshed.Core.FakeShell do
   Start an interactive fake shell session.
 
   The function prints a short banner then enters a read-execute loop.
-  Each non-empty line is passed to `Toolshed.cmd/1`. Type `"exit"` or send EOF
-  (Ctrl+D) to end the session. The function returns `:ok` on exit.
+  Each non-empty line is passed to `Toolshed.cmd/1`. Type `"exit"` to end the session. The function returns `:ok` on exit.
   """
   @spec fake_shell() :: :ok
   def fake_shell() do

--- a/lib_src/core/fake_shell.ex
+++ b/lib_src/core/fake_shell.ex
@@ -1,0 +1,61 @@
+defmodule Toolshed.Core.FakeShell do
+  @moduledoc """
+  Provides a small interactive fake shell used in tests and local development.
+
+  The shell reads lines from `IO.gets/1` and delegates command execution
+  to `Toolshed.cmd/1`. It is intended for manual use or lightweight
+  integration testing where an interactive prompt is convenient.
+
+    Example
+
+      iex> Toolshed.fake_shell()
+      Starting fake shell. Type 'exit' to quit.
+      fksh> echo hello
+      ...
+
+  The function returns `:ok` when the user types `exit` or when EOF is received.
+  """
+
+  @prompt "fksh> "
+
+  @doc """
+  Start an interactive fake shell session.
+
+  The function prints a short banner then enters a read-execute loop.
+  Each non-empty line is passed to `Toolshed.cmd/1`. Type `"exit"` or send EOF
+  (Ctrl+D) to end the session. The function returns `:ok` on exit.
+  """
+  @spec fake_shell() :: :ok
+  def fake_shell() do
+    IO.puts("Starting fake shell. Type 'exit' to quit.")
+    loop()
+  end
+
+  defp loop do
+    case IO.gets(@prompt) do
+      nil ->
+        :ok
+
+      "exit\n" ->
+        :ok
+
+      line ->
+        line
+        |> String.trim()
+        |> exec()
+
+        loop()
+    end
+  end
+
+  defp exec(""), do: :ok
+
+  defp exec(cmdline) do
+    try do
+      Toolshed.cmd(cmdline)
+    rescue
+      e ->
+        IO.puts("error: #{inspect(e)}")
+    end
+  end
+end

--- a/test/toolshed_test.exs
+++ b/test/toolshed_test.exs
@@ -12,6 +12,7 @@ defmodule ToolshedTest do
     cat: 1,
     cmd: 1,
     date: 0,
+    fake_shell: 0,
     geo: 0,
     geo: 1,
     grep: 2,


### PR DESCRIPTION
Hi,

I've used this when debugging my Nerves system. It redirects all lines from `IO.gets` to `cmd`. It's simply more convenient when debugging the Buildroot part of new Nerves systems.

It might be useful to others.
