### PR TITLE
Update HexDoc URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Toolshed
 
 [![Hex version](https://img.shields.io/hexpm/v/toolshed.svg "Hex version")](https://hex.pm/packages/toolshed)
-[![API docs](https://img.shields.io/hexpm/v/toolshed.svg?label=hexdocs "API docs")](https://hexdocs.pm/toolshed/Toolshed.html)
+[![API docs](https://img.shields.io/hexpm/v/toolshed.svg?label=hexdocs "API docs")](https://toolshed.hexdocs.pm/Toolshed.html)
 [![CircleCI](https://circleci.com/gh/elixir-toolshed/toolshed.svg?style=svg)](https://circleci.com/gh/elixir-toolshed/toolshed)
 [![REUSE status](https://api.reuse.software/badge/github.com/elixir-toolshed/toolshed)](https://api.reuse.software/info/github.com/elixir-toolshed/toolshed)
 
@@ -69,7 +69,7 @@ nerves_init_gadg #PID<0.1432.0>            213K/39K       0/0      192K/101K    
 ```
 
 When you get tired of typing `use Toolshed`, add it to your
-[`.iex.exs`](https://hexdocs.pm/iex/IEx.html#module-the-iex-exs-file).
+[`.iex.exs`](https://iex.hexdocs.pm/IEx.html#module-the-iex-exs-file).
 
 ## FAQ
 

--- a/lib_src/core/log_attach.ex
+++ b/lib_src/core/log_attach.ex
@@ -42,7 +42,7 @@ defmodule Toolshed.Core.LogAttach do
 
   Behind the scenes, this uses Erlang's `logger_std_h` and Elixir's log
   formatter. Options include all of the ones from
-  [Logger.Formatter](https://hexdocs.pm/logger/main/Logger.Formatter.html#new/1)
+  [Logger.Formatter](https://logger.hexdocs.pm/main/Logger.Formatter.html#new/1)
   and the ability to set the level.
 
   For ease of use, here are the common options:


### PR DESCRIPTION
Migrates HexDocs URLs to the 2026 format using hex_url_migrator.

<details>
<summary>⚠️ URL verification warnings from <code>hex_url_migrator --verify</code></summary>

```
❌ Verification failed for https://toolshed.hexdocs.pm/Toolshed.html): Status 404
⚠️ Verification finished: 2 success, 1 failure(s).
```

_Reported by the migrator's verifier. Note that `301`s are typically redirects (the target exists) and a trailing `)` is a markdown-link parsing artifact. Please review before merging._
</details>